### PR TITLE
CI: Add coverage reports and format checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           python-version: "3.12"
       - run: pip install ruff
       - run: ruff check scripts/ tests/
+      - name: Format check
+        run: python3 -m ruff format --check scripts/ tests/
 
   typecheck:
     runs-on: ubuntu-latest
@@ -46,15 +48,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - run: pip install -e ".[test]"
-      - run: python -m pytest tests/ -x -q --tb=short --cov=mind_mem --cov-report=xml --cov-report=term
+      - name: Test with coverage
+        run: python3 -m pytest tests/ --cov=scripts --cov-report=xml --cov-report=term-missing -x -q
         env:
           PYTHONDONTWRITEBYTECODE: "1"
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: coverage.xml
+          retention-days: 30
 
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add pytest coverage reporting (XML + terminal) with artifact upload
- Add ruff format --check for code style enforcement
- Coverage artifacts retained for 30 days per matrix job