### PR TITLE
Add structured error code registry

### DIFF
--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -1,0 +1,201 @@
+"""mind-mem Error Codes — structured error classification.
+
+Provides a canonical enum of error codes used across mind-mem modules.
+Each code maps to a category, severity, and human-readable description.
+
+Usage:
+    from scripts.error_codes import ErrorCode, error_message
+
+    raise ValueError(error_message(ErrorCode.WORKSPACE_NOT_FOUND))
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ErrorSeverity(Enum):
+    """Error severity levels."""
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ErrorCategory(Enum):
+    """Error categories for classification."""
+    WORKSPACE = "workspace"
+    CONFIG = "config"
+    STORAGE = "storage"
+    RETRIEVAL = "retrieval"
+    INDEX = "index"
+    VALIDATION = "validation"
+    NETWORK = "network"
+    PERMISSION = "permission"
+
+
+class ErrorCode(Enum):
+    """Canonical error codes for mind-mem operations."""
+
+    # Workspace errors (1xxx)
+    WORKSPACE_NOT_FOUND = 1001
+    WORKSPACE_NOT_INITIALIZED = 1002
+    WORKSPACE_CORRUPTED = 1003
+
+    # Config errors (2xxx)
+    CONFIG_INVALID_JSON = 2001
+    CONFIG_MISSING_KEY = 2002
+    CONFIG_VALUE_OUT_OF_RANGE = 2003
+    CONFIG_FILE_UNREADABLE = 2004
+
+    # Storage errors (3xxx)
+    STORAGE_WRITE_FAILED = 3001
+    STORAGE_READ_FAILED = 3002
+    STORAGE_LOCK_TIMEOUT = 3003
+    STORAGE_DISK_FULL = 3004
+    STORAGE_BLOCK_CORRUPTED = 3005
+
+    # Retrieval errors (4xxx)
+    RECALL_NO_RESULTS = 4001
+    RECALL_INDEX_STALE = 4002
+    RECALL_QUERY_TOO_LONG = 4003
+    RECALL_TIMEOUT = 4004
+
+    # Index errors (5xxx)
+    INDEX_BUILD_FAILED = 5001
+    INDEX_CORRUPTED = 5002
+    INDEX_VERSION_MISMATCH = 5003
+    INDEX_REINDEX_REQUIRED = 5004
+
+    # Validation errors (6xxx)
+    VALIDATE_BLOCK_MALFORMED = 6001
+    VALIDATE_SCHEMA_MISMATCH = 6002
+    VALIDATE_DUPLICATE_ID = 6003
+    VALIDATE_CONTENT_HASH_MISMATCH = 6004
+
+    # Network errors (7xxx)
+    NETWORK_LLM_UNAVAILABLE = 7001
+    NETWORK_EMBEDDING_FAILED = 7002
+    NETWORK_TIMEOUT = 7003
+
+    # Permission errors (8xxx)
+    PERMISSION_DENIED = 8001
+    PERMISSION_READONLY_WORKSPACE = 8002
+
+
+# Error metadata registry
+_ERROR_METADATA: dict[ErrorCode, tuple[ErrorCategory, ErrorSeverity, str]] = {
+    ErrorCode.WORKSPACE_NOT_FOUND: (
+        ErrorCategory.WORKSPACE, ErrorSeverity.HIGH,
+        "Workspace directory does not exist"),
+    ErrorCode.WORKSPACE_NOT_INITIALIZED: (
+        ErrorCategory.WORKSPACE, ErrorSeverity.HIGH,
+        "Workspace has not been initialized (missing MEMORY.md)"),
+    ErrorCode.WORKSPACE_CORRUPTED: (
+        ErrorCategory.WORKSPACE, ErrorSeverity.CRITICAL,
+        "Workspace structure is corrupted or incomplete"),
+    ErrorCode.CONFIG_INVALID_JSON: (
+        ErrorCategory.CONFIG, ErrorSeverity.MEDIUM,
+        "Configuration file contains invalid JSON"),
+    ErrorCode.CONFIG_MISSING_KEY: (
+        ErrorCategory.CONFIG, ErrorSeverity.LOW,
+        "Required configuration key is missing"),
+    ErrorCode.CONFIG_VALUE_OUT_OF_RANGE: (
+        ErrorCategory.CONFIG, ErrorSeverity.LOW,
+        "Configuration value is outside acceptable range"),
+    ErrorCode.CONFIG_FILE_UNREADABLE: (
+        ErrorCategory.CONFIG, ErrorSeverity.MEDIUM,
+        "Configuration file cannot be read"),
+    ErrorCode.STORAGE_WRITE_FAILED: (
+        ErrorCategory.STORAGE, ErrorSeverity.HIGH,
+        "Failed to write data to storage"),
+    ErrorCode.STORAGE_READ_FAILED: (
+        ErrorCategory.STORAGE, ErrorSeverity.HIGH,
+        "Failed to read data from storage"),
+    ErrorCode.STORAGE_LOCK_TIMEOUT: (
+        ErrorCategory.STORAGE, ErrorSeverity.MEDIUM,
+        "File lock acquisition timed out"),
+    ErrorCode.STORAGE_DISK_FULL: (
+        ErrorCategory.STORAGE, ErrorSeverity.CRITICAL,
+        "Insufficient disk space for write operation"),
+    ErrorCode.STORAGE_BLOCK_CORRUPTED: (
+        ErrorCategory.STORAGE, ErrorSeverity.HIGH,
+        "Memory block data is corrupted"),
+    ErrorCode.RECALL_NO_RESULTS: (
+        ErrorCategory.RETRIEVAL, ErrorSeverity.LOW,
+        "No results found for recall query"),
+    ErrorCode.RECALL_INDEX_STALE: (
+        ErrorCategory.RETRIEVAL, ErrorSeverity.MEDIUM,
+        "Search index is stale and may return incomplete results"),
+    ErrorCode.RECALL_QUERY_TOO_LONG: (
+        ErrorCategory.RETRIEVAL, ErrorSeverity.LOW,
+        "Query exceeds maximum length"),
+    ErrorCode.RECALL_TIMEOUT: (
+        ErrorCategory.RETRIEVAL, ErrorSeverity.MEDIUM,
+        "Recall operation timed out"),
+    ErrorCode.INDEX_BUILD_FAILED: (
+        ErrorCategory.INDEX, ErrorSeverity.HIGH,
+        "Failed to build search index"),
+    ErrorCode.INDEX_CORRUPTED: (
+        ErrorCategory.INDEX, ErrorSeverity.HIGH,
+        "Search index is corrupted"),
+    ErrorCode.INDEX_VERSION_MISMATCH: (
+        ErrorCategory.INDEX, ErrorSeverity.MEDIUM,
+        "Index version does not match expected schema"),
+    ErrorCode.INDEX_REINDEX_REQUIRED: (
+        ErrorCategory.INDEX, ErrorSeverity.MEDIUM,
+        "Full reindex required after schema change"),
+    ErrorCode.VALIDATE_BLOCK_MALFORMED: (
+        ErrorCategory.VALIDATION, ErrorSeverity.MEDIUM,
+        "Memory block structure is malformed"),
+    ErrorCode.VALIDATE_SCHEMA_MISMATCH: (
+        ErrorCategory.VALIDATION, ErrorSeverity.MEDIUM,
+        "Data does not match expected schema"),
+    ErrorCode.VALIDATE_DUPLICATE_ID: (
+        ErrorCategory.VALIDATION, ErrorSeverity.LOW,
+        "Duplicate block ID detected"),
+    ErrorCode.VALIDATE_CONTENT_HASH_MISMATCH: (
+        ErrorCategory.VALIDATION, ErrorSeverity.HIGH,
+        "Content hash does not match stored value"),
+    ErrorCode.NETWORK_LLM_UNAVAILABLE: (
+        ErrorCategory.NETWORK, ErrorSeverity.MEDIUM,
+        "LLM provider is unavailable"),
+    ErrorCode.NETWORK_EMBEDDING_FAILED: (
+        ErrorCategory.NETWORK, ErrorSeverity.MEDIUM,
+        "Embedding generation failed"),
+    ErrorCode.NETWORK_TIMEOUT: (
+        ErrorCategory.NETWORK, ErrorSeverity.MEDIUM,
+        "Network request timed out"),
+    ErrorCode.PERMISSION_DENIED: (
+        ErrorCategory.PERMISSION, ErrorSeverity.HIGH,
+        "Permission denied for requested operation"),
+    ErrorCode.PERMISSION_READONLY_WORKSPACE: (
+        ErrorCategory.PERMISSION, ErrorSeverity.MEDIUM,
+        "Workspace is in read-only mode"),
+}
+
+
+def error_message(code: ErrorCode) -> str:
+    """Get human-readable error message for an error code."""
+    meta = _ERROR_METADATA.get(code)
+    if meta is None:
+        return f"Unknown error (code {code.value})"
+    _, _, message = meta
+    return f"[MM-{code.value}] {message}"
+
+
+def error_category(code: ErrorCode) -> ErrorCategory:
+    """Get the category for an error code."""
+    meta = _ERROR_METADATA.get(code)
+    return meta[0] if meta else ErrorCategory.WORKSPACE
+
+
+def error_severity(code: ErrorCode) -> ErrorSeverity:
+    """Get the severity for an error code."""
+    meta = _ERROR_METADATA.get(code)
+    return meta[1] if meta else ErrorSeverity.MEDIUM
+
+
+def is_critical(code: ErrorCode) -> bool:
+    """Check if an error code is critical severity."""
+    return error_severity(code) == ErrorSeverity.CRITICAL

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -1,0 +1,268 @@
+"""Tests for mind-mem Error Codes module."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.error_codes import (
+    ErrorCategory,
+    ErrorCode,
+    ErrorSeverity,
+    _ERROR_METADATA,
+    error_category,
+    error_message,
+    error_severity,
+    is_critical,
+)
+
+
+# ---------------------------------------------------------------------------
+# Completeness: every ErrorCode has a metadata entry
+# ---------------------------------------------------------------------------
+
+class TestMetadataCompleteness:
+    """Every ErrorCode member must have metadata."""
+
+    def test_all_codes_have_metadata(self):
+        missing = [c for c in ErrorCode if c not in _ERROR_METADATA]
+        assert missing == [], f"ErrorCodes missing metadata: {missing}"
+
+    def test_metadata_has_no_extra_keys(self):
+        extras = [k for k in _ERROR_METADATA if k not in ErrorCode]
+        assert extras == [], f"Metadata has keys not in ErrorCode: {extras}"
+
+    def test_metadata_tuple_structure(self):
+        for code, meta in _ERROR_METADATA.items():
+            assert isinstance(meta, tuple), f"{code}: metadata is not a tuple"
+            assert len(meta) == 3, f"{code}: metadata tuple length != 3"
+            cat, sev, msg = meta
+            assert isinstance(cat, ErrorCategory), f"{code}: bad category type"
+            assert isinstance(sev, ErrorSeverity), f"{code}: bad severity type"
+            assert isinstance(msg, str) and len(msg) > 0, f"{code}: bad message"
+
+
+# ---------------------------------------------------------------------------
+# Numeric range conventions
+# ---------------------------------------------------------------------------
+
+_RANGE_MAP: dict[str, tuple[int, int, ErrorCategory]] = {
+    "WORKSPACE": (1000, 1999, ErrorCategory.WORKSPACE),
+    "CONFIG": (2000, 2999, ErrorCategory.CONFIG),
+    "STORAGE": (3000, 3999, ErrorCategory.STORAGE),
+    "RECALL": (4000, 4999, ErrorCategory.RETRIEVAL),
+    "INDEX": (5000, 5999, ErrorCategory.INDEX),
+    "VALIDATE": (6000, 6999, ErrorCategory.VALIDATION),
+    "NETWORK": (7000, 7999, ErrorCategory.NETWORK),
+    "PERMISSION": (8000, 8999, ErrorCategory.PERMISSION),
+}
+
+
+class TestNumericRanges:
+    """Error code numeric values must match category conventions."""
+
+    @pytest.mark.parametrize("code", list(ErrorCode))
+    def test_code_in_expected_range(self, code: ErrorCode):
+        prefix = code.name.split("_")[0]
+        lo, hi, expected_cat = _RANGE_MAP[prefix]
+        assert lo <= code.value <= hi, (
+            f"{code.name} value {code.value} outside [{lo}, {hi}]"
+        )
+        assert error_category(code) == expected_cat, (
+            f"{code.name} category {error_category(code)} != {expected_cat}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# error_message()
+# ---------------------------------------------------------------------------
+
+class TestErrorMessage:
+    """error_message() returns formatted strings."""
+
+    @pytest.mark.parametrize("code", list(ErrorCode))
+    def test_format_prefix(self, code: ErrorCode):
+        msg = error_message(code)
+        assert msg.startswith(f"[MM-{code.value}]"), (
+            f"Message for {code.name} missing prefix: {msg}"
+        )
+
+    def test_workspace_not_found_message(self):
+        msg = error_message(ErrorCode.WORKSPACE_NOT_FOUND)
+        assert msg == "[MM-1001] Workspace directory does not exist"
+
+    def test_storage_disk_full_message(self):
+        msg = error_message(ErrorCode.STORAGE_DISK_FULL)
+        assert msg == "[MM-3004] Insufficient disk space for write operation"
+
+    def test_message_is_nonempty_after_prefix(self):
+        for code in ErrorCode:
+            msg = error_message(code)
+            after_prefix = msg.split("] ", 1)[1]
+            assert len(after_prefix) > 0
+
+
+# ---------------------------------------------------------------------------
+# error_category()
+# ---------------------------------------------------------------------------
+
+class TestErrorCategory:
+    """error_category() returns the correct ErrorCategory."""
+
+    def test_workspace_codes(self):
+        for code in (
+            ErrorCode.WORKSPACE_NOT_FOUND,
+            ErrorCode.WORKSPACE_NOT_INITIALIZED,
+            ErrorCode.WORKSPACE_CORRUPTED,
+        ):
+            assert error_category(code) == ErrorCategory.WORKSPACE
+
+    def test_config_codes(self):
+        for code in (
+            ErrorCode.CONFIG_INVALID_JSON,
+            ErrorCode.CONFIG_MISSING_KEY,
+            ErrorCode.CONFIG_VALUE_OUT_OF_RANGE,
+            ErrorCode.CONFIG_FILE_UNREADABLE,
+        ):
+            assert error_category(code) == ErrorCategory.CONFIG
+
+    def test_storage_codes(self):
+        for code in (
+            ErrorCode.STORAGE_WRITE_FAILED,
+            ErrorCode.STORAGE_READ_FAILED,
+            ErrorCode.STORAGE_LOCK_TIMEOUT,
+            ErrorCode.STORAGE_DISK_FULL,
+            ErrorCode.STORAGE_BLOCK_CORRUPTED,
+        ):
+            assert error_category(code) == ErrorCategory.STORAGE
+
+    def test_retrieval_codes(self):
+        for code in (
+            ErrorCode.RECALL_NO_RESULTS,
+            ErrorCode.RECALL_INDEX_STALE,
+            ErrorCode.RECALL_QUERY_TOO_LONG,
+            ErrorCode.RECALL_TIMEOUT,
+        ):
+            assert error_category(code) == ErrorCategory.RETRIEVAL
+
+    def test_index_codes(self):
+        for code in (
+            ErrorCode.INDEX_BUILD_FAILED,
+            ErrorCode.INDEX_CORRUPTED,
+            ErrorCode.INDEX_VERSION_MISMATCH,
+            ErrorCode.INDEX_REINDEX_REQUIRED,
+        ):
+            assert error_category(code) == ErrorCategory.INDEX
+
+    def test_validation_codes(self):
+        for code in (
+            ErrorCode.VALIDATE_BLOCK_MALFORMED,
+            ErrorCode.VALIDATE_SCHEMA_MISMATCH,
+            ErrorCode.VALIDATE_DUPLICATE_ID,
+            ErrorCode.VALIDATE_CONTENT_HASH_MISMATCH,
+        ):
+            assert error_category(code) == ErrorCategory.VALIDATION
+
+    def test_network_codes(self):
+        for code in (
+            ErrorCode.NETWORK_LLM_UNAVAILABLE,
+            ErrorCode.NETWORK_EMBEDDING_FAILED,
+            ErrorCode.NETWORK_TIMEOUT,
+        ):
+            assert error_category(code) == ErrorCategory.NETWORK
+
+    def test_permission_codes(self):
+        for code in (
+            ErrorCode.PERMISSION_DENIED,
+            ErrorCode.PERMISSION_READONLY_WORKSPACE,
+        ):
+            assert error_category(code) == ErrorCategory.PERMISSION
+
+
+# ---------------------------------------------------------------------------
+# error_severity()
+# ---------------------------------------------------------------------------
+
+class TestErrorSeverity:
+    """error_severity() returns the correct ErrorSeverity."""
+
+    def test_critical_codes(self):
+        critical_codes = [
+            ErrorCode.WORKSPACE_CORRUPTED,
+            ErrorCode.STORAGE_DISK_FULL,
+        ]
+        for code in critical_codes:
+            assert error_severity(code) == ErrorSeverity.CRITICAL, (
+                f"{code.name} should be CRITICAL"
+            )
+
+    def test_high_codes(self):
+        high_codes = [
+            ErrorCode.WORKSPACE_NOT_FOUND,
+            ErrorCode.WORKSPACE_NOT_INITIALIZED,
+            ErrorCode.STORAGE_WRITE_FAILED,
+            ErrorCode.STORAGE_READ_FAILED,
+            ErrorCode.STORAGE_BLOCK_CORRUPTED,
+            ErrorCode.INDEX_BUILD_FAILED,
+            ErrorCode.INDEX_CORRUPTED,
+            ErrorCode.VALIDATE_CONTENT_HASH_MISMATCH,
+            ErrorCode.PERMISSION_DENIED,
+        ]
+        for code in high_codes:
+            assert error_severity(code) == ErrorSeverity.HIGH, (
+                f"{code.name} should be HIGH"
+            )
+
+    def test_low_codes(self):
+        low_codes = [
+            ErrorCode.CONFIG_MISSING_KEY,
+            ErrorCode.CONFIG_VALUE_OUT_OF_RANGE,
+            ErrorCode.RECALL_NO_RESULTS,
+            ErrorCode.RECALL_QUERY_TOO_LONG,
+            ErrorCode.VALIDATE_DUPLICATE_ID,
+        ]
+        for code in low_codes:
+            assert error_severity(code) == ErrorSeverity.LOW, (
+                f"{code.name} should be LOW"
+            )
+
+
+# ---------------------------------------------------------------------------
+# is_critical()
+# ---------------------------------------------------------------------------
+
+class TestIsCritical:
+    """is_critical() returns True only for CRITICAL severity codes."""
+
+    def test_critical_true(self):
+        assert is_critical(ErrorCode.WORKSPACE_CORRUPTED) is True
+        assert is_critical(ErrorCode.STORAGE_DISK_FULL) is True
+
+    def test_critical_false(self):
+        assert is_critical(ErrorCode.WORKSPACE_NOT_FOUND) is False
+        assert is_critical(ErrorCode.CONFIG_MISSING_KEY) is False
+        assert is_critical(ErrorCode.RECALL_NO_RESULTS) is False
+        assert is_critical(ErrorCode.NETWORK_TIMEOUT) is False
+
+    @pytest.mark.parametrize("code", list(ErrorCode))
+    def test_is_critical_matches_severity(self, code: ErrorCode):
+        expected = error_severity(code) == ErrorSeverity.CRITICAL
+        assert is_critical(code) is expected
+
+
+# ---------------------------------------------------------------------------
+# Enum value uniqueness
+# ---------------------------------------------------------------------------
+
+class TestEnumIntegrity:
+    """ErrorCode enum values must be unique integers."""
+
+    def test_all_values_are_ints(self):
+        for code in ErrorCode:
+            assert isinstance(code.value, int)
+
+    def test_no_duplicate_values(self):
+        values = [c.value for c in ErrorCode]
+        assert len(values) == len(set(values)), "Duplicate ErrorCode values found"
+
+    def test_total_count(self):
+        assert len(ErrorCode) == 29, f"Expected 29 error codes, got {len(ErrorCode)}"


### PR DESCRIPTION
Add ErrorCode enum with 29 error codes across 8 categories, each with severity classification and human-readable messages. Fully tested with 109 tests.