### PR TITLE
Add .editorconfig for cross-editor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+max_line_length = 120
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.toml]
+indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Configure indent style, line endings, charset, and trailing whitespace rules for Python, Markdown, YAML, JSON, and Makefile.