### PR TITLE
Fix tomllib import for Python 3.10 compatibility

### DIFF
--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -10,17 +10,26 @@ from __future__ import annotations
 
 import re
 import sys
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None  # type: ignore[assignment]
 
 
 def get_pyproject_version() -> str | None:
     """Read version from pyproject.toml."""
     try:
-        with open("pyproject.toml", "rb") as f:
-            data = tomllib.load(f)
-        return data.get("project", {}).get("version")
-    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        if tomllib is not None:
+            with open("pyproject.toml", "rb") as f:
+                data = tomllib.load(f)
+            return data.get("project", {}).get("version")
+        # Regex fallback for Python <3.11 (no tomllib)
+        content = Path("pyproject.toml").read_text()
+        m = re.search(r'version\s*=\s*"([^"]+)"', content)
+        return m.group(1) if m else None
+    except FileNotFoundError:
         return None
 
 


### PR DESCRIPTION
## Summary
- `tomllib` was added in Python 3.11 but CI matrix includes Python 3.10
- Added regex fallback for `pyproject.toml` version extraction when `tomllib` is unavailable
- Fixes CI failure on Python 3.10 runners

## Test plan
- [ ] CI passes on Python 3.10
- [ ] Version checker still works on Python 3.11+