### PR TITLE
Fix benchmark recall() argument order

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,11 +51,11 @@ jobs:
 
           blocks = parse_file(blocks_md)
 
-          # Benchmark recall
+          # Benchmark recall (signature: recall(workspace, query, limit=...))
           times = []
           for _ in range(10):
               start = time.perf_counter()
-              recall('test decision topic', blocks, limit=10)
+              recall(ws, 'test decision topic', limit=10)
               elapsed = (time.perf_counter() - start) * 1000
               times.append(elapsed)
 


### PR DESCRIPTION
## Summary
- `recall()` signature is `recall(workspace, query, limit=...)` but benchmark was calling `recall(query, blocks, limit=...)`
- Fixed to pass workspace path as first argument and query string as second
- Fixes `AttributeError: 'list' object has no attribute 'lower'` in CI

## Test plan
- [ ] Benchmark workflow passes
- [ ] Recall timing results are reasonable (<500ms)