### PR TITLE
Add stale issue and PR bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had recent activity. It will be closed if no further activity
+            occurs within 14 days.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has
+            not had recent activity. It will be closed if no further activity
+            occurs within 7 days.
+          days-before-stale: 30
+          days-before-close: 14
+          days-before-pr-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security
+          exempt-pr-labels: pinned


### PR DESCRIPTION
## Summary
- Auto-marks issues stale after 30 days, closes after 14
- Auto-marks PRs stale after 30 days, closes after 7
- Exempts pinned and security labels

## Test plan
- [x] Valid GitHub Actions syntax