### PR TITLE
Polish codebase: fix all re-audit findings

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          pip install -e ".[test,benchmark]"
 
       - name: Run benchmark suite
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ on:
       - 'CHANGELOG.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: python -m build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -40,13 +40,13 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # release/v1
         with:
           print-hash: true
 
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
 
-      - uses: anthropics/claude-code-security-review@main
+      - uses: anthropics/claude-code-security-review@0c6a49f1fa56a1d472575da86a94dbc1edb78eda  # main
         with:
           comment-pr: ${{ github.event_name == 'pull_request' }}
           upload-results: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ mind-mem is a **local-first** library that operates entirely on the user's files
 | SQL injection via FTS5 queries | All SQLite queries use parameterized bindings (`?` placeholders); zero string interpolation in SQL | Active |
 | Arbitrary code execution via LLM extraction | Extraction output is treated as plain text; never evaluated as code | Active |
 | File lock starvation / race conditions | Cross-platform advisory locking via `fcntl`/`msvcrt`/atomic create with stale PID cleanup (`mind_filelock.py`) | Active |
-| MCP token auth bypass (HTTP mode) | Bearer token validation on every request; constant-time comparison; token required when `MIND_MEM_TOKEN` is set | Active |
+| MCP token auth bypass (HTTP mode) | Bearer token validation on every request; constant-time comparison; token required when `MIND_MEM_TOKEN` is set. Admin scope for privileged tools is controlled via `MIND_MEM_SCOPE=admin` env var (not Bearer token) | Active |
 | Denial of service via large workspaces | Configurable `top_k` limits, knee cutoff truncation, proposal budget caps (`per_run`, `per_day`, `backlog_limit`) | Active |
 | Concurrent SQLite write corruption | WAL journal mode, `busy_timeout=3000`, `timeout=5` on all connections, `try/finally` cleanup | Active |
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -97,6 +97,8 @@ from mind_mem.sqlite_index import (  # noqa: E402
 
 _log = get_logger("mcp_server")
 
+MCP_SCHEMA_VERSION = "1.0"
+
 
 # ---------------------------------------------------------------------------
 # ACL — per-tool scope enforcement (#20)
@@ -136,32 +138,6 @@ USER_TOOLS = frozenset(
 )
 
 
-def _resolve_scope(headers: dict | None = None) -> str:
-    """Determine caller scope from token.
-
-    Returns "admin" if the request carries the admin token,
-    "user" for the regular token, or "user" when no auth is configured.
-    """
-    admin_token = os.environ.get("MIND_MEM_ADMIN_TOKEN")
-    if not admin_token:
-        return "user"
-
-    if headers is None:
-        return "user"
-
-    # Extract token from headers
-    auth = headers.get("authorization", headers.get("Authorization", ""))
-    provided = ""
-    if auth.startswith("Bearer "):
-        provided = auth[7:]
-    if not provided:
-        provided = headers.get("x-mindmem-token", headers.get("X-MindMem-Token", ""))
-
-    if provided and hmac.compare_digest(provided, admin_token):
-        return "admin"
-    return "user"
-
-
 def check_tool_acl(tool_name: str, scope: str) -> str | None:
     """Check whether *scope* is allowed to call *tool_name*.
 
@@ -174,7 +150,7 @@ def check_tool_acl(tool_name: str, scope: str) -> str | None:
             {
                 "error": f"Permission denied: '{tool_name}' requires admin scope",
                 "scope": scope,
-                "hint": "Set MIND_MEM_ADMIN_TOKEN and pass it via Authorization header.",
+                "hint": "Admin scope is controlled via MIND_MEM_SCOPE=admin env var.",
             }
         )
     return None
@@ -264,7 +240,7 @@ def _sqlite_busy_error() -> str:
     """Return structured JSON error for SQLite database locked (#29)."""
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "error": "database_busy",
             "message": "Database is temporarily locked by another process",
             "retry_after_seconds": 1,
@@ -299,6 +275,9 @@ def mcp_tool_observe(fn):
             if acl_error:
                 _log.warning("acl_blocked", tool=tool_name, scope=scope)
                 return acl_error
+        elif admin_token and tool_name not in USER_TOOLS:
+            _log.warning("acl_unknown_tool", tool=tool_name)
+            return json.dumps({"error": f"Tool '{tool_name}' is not in ACL policy", "_schema_version": "1.0"})
 
         start = time.monotonic()
         error_type = None
@@ -416,7 +395,7 @@ def _load_config(ws: str) -> dict:
             msg=str(exc),
         )
         # Fall back to built-in defaults
-        from init_workspace import DEFAULT_CONFIG
+        from mind_mem.init_workspace import DEFAULT_CONFIG
 
         return dict(DEFAULT_CONFIG)
     except (OSError, UnicodeDecodeError) as exc:
@@ -600,7 +579,7 @@ def _recall_impl(query: str, limit: int = 10, active_only: bool = False, backend
     metrics.inc("mcp_recall_queries")
     _log.info("mcp_recall", query=query, backend=used_backend, results=len(results))
     envelope: dict = {
-        "_schema_version": "1.0",
+        "_schema_version": MCP_SCHEMA_VERSION,
         "backend": used_backend,
         "query": query,
         "count": len(results),
@@ -699,7 +678,7 @@ def propose_update(
 
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "status": "proposed",
             "written": written,
             "location": "intelligence/SIGNALS.md",
@@ -723,7 +702,7 @@ def scan() -> str:
     if ws_err:
         return ws_err
 
-    result = {"_schema_version": "1.0", "checks": {}}
+    result = {"_schema_version": MCP_SCHEMA_VERSION, "checks": {}}
 
     # Parse decisions
     decisions_path = os.path.join(ws, "decisions", "DECISIONS.md")
@@ -792,7 +771,7 @@ def list_contradictions() -> str:
     if not resolutions:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "status": "clean",
                 "contradictions": 0,
                 "message": "No contradictions found.",
@@ -801,7 +780,7 @@ def list_contradictions() -> str:
 
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "status": "contradictions_found",
             "contradictions": len(resolutions),
             "resolutions": resolutions,
@@ -850,7 +829,7 @@ def approve_apply(proposal_id: str, dry_run: bool = True) -> str:
 
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "status": "applied" if success and not dry_run else "dry_run_passed" if success else "failed",
             "proposal_id": proposal_id,
             "dry_run": dry_run,
@@ -899,7 +878,7 @@ def rollback_proposal(receipt_ts: str) -> str:
 
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "status": "rolled_back" if success else "rollback_failed",
             "receipt_ts": receipt_ts,
             "success": success,
@@ -958,7 +937,7 @@ def find_similar(block_id: str, limit: int = 5) -> str:
         metrics.inc("mcp_find_similar_queries")
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "source": block_id,
                 "similar": co_blocks,
                 "method": "co-occurrence",
@@ -968,7 +947,7 @@ def find_similar(block_id: str, limit: int = 5) -> str:
     except ImportError:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "find_similar requires block_metadata module",
                 "block_id": block_id,
             },
@@ -982,7 +961,7 @@ def find_similar(block_id: str, limit: int = 5) -> str:
         _log.warning("find_similar_failed", block_id=block_id, error=str(exc))
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "Failed to find similar blocks. The co-occurrence index may not be initialized.",
                 "block_id": block_id,
             },
@@ -1012,7 +991,7 @@ def intent_classify(query: str) -> str:
         metrics.inc("mcp_intent_classify")
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "query": query,
                 "intent": result.intent,
                 "confidence": result.confidence,
@@ -1024,7 +1003,7 @@ def intent_classify(query: str) -> str:
     except ImportError:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "intent_router module not available",
                 "query": query,
             },
@@ -1034,7 +1013,7 @@ def intent_classify(query: str) -> str:
         _log.warning("intent_classify_failed", query=query, error=str(exc))
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "Intent classification failed",
                 "query": query,
             },
@@ -1051,7 +1030,7 @@ def index_stats() -> str:
         JSON with workspace statistics.
     """
     ws = _workspace()
-    stats: dict = {"_schema_version": "1.0"}
+    stats: dict = {"_schema_version": MCP_SCHEMA_VERSION}
 
     # Use FTS index for block counts when available (O(1) vs O(N) file parsing)
     db = fts_db_path(ws)
@@ -1117,7 +1096,7 @@ def reindex(include_vectors: bool = False) -> str:
     ws_err = _check_workspace(ws)
     if ws_err:
         return ws_err
-    results: dict = {"_schema_version": "1.0", "fts": False, "vectors": False}
+    results: dict = {"_schema_version": MCP_SCHEMA_VERSION, "fts": False, "vectors": False}
 
     try:
         from mind_mem.sqlite_index import build_index
@@ -1146,7 +1125,7 @@ def reindex(include_vectors: bool = False) -> str:
 
     # Regenerate category summaries
     try:
-        from category_distiller import CategoryDistiller
+        from mind_mem.category_distiller import CategoryDistiller
 
         extra_cats = _load_extra_categories(ws)
         distiller = CategoryDistiller(extra_categories=extra_cats if extra_cats else None)
@@ -1188,7 +1167,7 @@ def memory_evolution(block_id: str, action: str = "get") -> str:
             metrics.inc("mcp_evolution_updates")
             return json.dumps(
                 {
-                    "_schema_version": "1.0",
+                    "_schema_version": MCP_SCHEMA_VERSION,
                     "block_id": block_id,
                     "action": "updated",
                     "importance": round(importance, 4),
@@ -1201,7 +1180,7 @@ def memory_evolution(block_id: str, action: str = "get") -> str:
             metrics.inc("mcp_evolution_reads")
             return json.dumps(
                 {
-                    "_schema_version": "1.0",
+                    "_schema_version": MCP_SCHEMA_VERSION,
                     "block_id": block_id,
                     "importance": round(importance, 4),
                     "co_occurring_blocks": co_blocks,
@@ -1212,7 +1191,7 @@ def memory_evolution(block_id: str, action: str = "get") -> str:
     except ImportError:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "memory_evolution requires block_metadata module",
                 "block_id": block_id,
             },
@@ -1226,7 +1205,7 @@ def memory_evolution(block_id: str, action: str = "get") -> str:
         _log.warning("memory_evolution_failed", block_id=block_id, error=str(exc))
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "Memory evolution lookup failed. Access history may not be initialized.",
                 "block_id": block_id,
             },
@@ -1257,7 +1236,7 @@ def category_summary(topic: str, limit: int = 3) -> str:
     ws = _workspace()
     limits = _get_limits(ws)
     try:
-        from category_distiller import CategoryDistiller
+        from mind_mem.category_distiller import CategoryDistiller
 
         extra_cats = _load_extra_categories(ws)
         distiller = CategoryDistiller(extra_categories=extra_cats if extra_cats else None)
@@ -1268,7 +1247,7 @@ def category_summary(topic: str, limit: int = 3) -> str:
         if not context:
             return json.dumps(
                 {
-                    "_schema_version": "1.0",
+                    "_schema_version": MCP_SCHEMA_VERSION,
                     "topic": topic,
                     "status": "no_categories",
                     "hint": "Run reindex to generate category files, or add blocks with matching tags.",
@@ -1277,7 +1256,7 @@ def category_summary(topic: str, limit: int = 3) -> str:
             )
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "topic": topic,
                 "matched_categories": cats[:limit],
                 "content": context,
@@ -1287,7 +1266,7 @@ def category_summary(topic: str, limit: int = 3) -> str:
     except ImportError:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "category_distiller module not available",
             }
         )
@@ -1295,7 +1274,7 @@ def category_summary(topic: str, limit: int = 3) -> str:
         _log.warning("category_summary_failed", topic=topic, error=str(exc))
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "Category summary lookup failed",
                 "topic": topic,
             },
@@ -1324,7 +1303,7 @@ def prefetch(signals: str, limit: int = 5) -> str:
     if not signal_list:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "No signals provided. Pass comma-separated keywords.",
             }
         )
@@ -1339,7 +1318,7 @@ def prefetch(signals: str, limit: int = 5) -> str:
         _log.info("mcp_prefetch", signals=signal_list, results=len(results))
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "signals": signal_list,
                 "count": len(results),
                 "results": results,
@@ -1353,7 +1332,7 @@ def prefetch(signals: str, limit: int = 5) -> str:
         _log.warning("prefetch_failed", signals=signal_list, traceback=traceback.format_exc())
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": "Prefetch failed",
                 "signals": signal_list,
             },
@@ -1394,7 +1373,7 @@ def list_mind_kernels() -> str:
     _log.info("mcp_list_kernels", count=len(result))
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "kernels": result,
         },
         indent=2,
@@ -1418,7 +1397,7 @@ def get_mind_kernel(name: str) -> str:
     if not _re_mod.match(r"^[a-zA-Z0-9_-]{1,64}$", name):
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": f"Invalid kernel name: {name}",
             }
         )
@@ -1431,7 +1410,7 @@ def get_mind_kernel(name: str) -> str:
     if not cfg:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": f"Kernel '{name}' not found",
             }
         )
@@ -1440,7 +1419,7 @@ def get_mind_kernel(name: str) -> str:
     _log.info("mcp_get_kernel", name=name, sections=list(cfg.keys()))
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "name": name,
             "config": cfg,
         },
@@ -1497,7 +1476,7 @@ def delete_memory_item(block_id: str) -> str:
     if not _re_mod.match(r"^[A-Z]+-[a-zA-Z0-9-]+$", block_id):
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": f"Invalid block ID format: {block_id}",
             }
         )
@@ -1506,7 +1485,7 @@ def delete_memory_item(block_id: str) -> str:
     if filepath is None:
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": f"Unrecognized block ID prefix: {block_id}",
                 "hint": "Supported prefixes: " + ", ".join(sorted(_BLOCK_PREFIX_MAP.keys())),
             }
@@ -1515,7 +1494,7 @@ def delete_memory_item(block_id: str) -> str:
     if not os.path.isfile(filepath):
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": f"Source file not found: {filepath}",
                 "block_id": block_id,
             }
@@ -1544,7 +1523,7 @@ def delete_memory_item(block_id: str) -> str:
         if block_start is None:
             return json.dumps(
                 {
-                    "_schema_version": "1.0",
+                    "_schema_version": MCP_SCHEMA_VERSION,
                     "error": f"Block {block_id} not found in {os.path.basename(filepath)}",
                     "block_id": block_id,
                 }
@@ -1577,7 +1556,7 @@ def delete_memory_item(block_id: str) -> str:
 
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "status": "deleted",
             "block_id": block_id,
             "file": os.path.basename(filepath),
@@ -1610,7 +1589,7 @@ def export_memory(format: str = "jsonl", include_metadata: bool = False) -> str:
     if format != "jsonl":
         return json.dumps(
             {
-                "_schema_version": "1.0",
+                "_schema_version": MCP_SCHEMA_VERSION,
                 "error": f"Unsupported format: {format}. Use 'jsonl'.",
             }
         )
@@ -1649,7 +1628,7 @@ def export_memory(format: str = "jsonl", include_metadata: bool = False) -> str:
 
     return json.dumps(
         {
-            "_schema_version": "1.0",
+            "_schema_version": MCP_SCHEMA_VERSION,
             "format": format,
             "block_count": len(all_blocks),
             "data": jsonl_output,
@@ -1722,8 +1701,8 @@ def main():
 
     # File watcher: auto-reindex on .md changes
     if args.watch:
-        from scripts.watcher import FileWatcher
-        from scripts.sqlite_index import build_index
+        from mind_mem.watcher import FileWatcher
+        from mind_mem.sqlite_index import build_index
 
         ws = _workspace()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ test = ["pytest>=7.4,<9.0", "pytest-cov>=6.0,<7.0", "mypy>=1.14,<2.0"]
 mcp = ["fastmcp==2.14.5"]
 embeddings = ["onnxruntime==1.24.2", "tokenizers==0.22.2"]
 cross-encoder = ["sentence-transformers==5.2.3"]
-all = ["fastmcp==2.14.5", "sentence-transformers==5.2.3"]
+benchmark = ["pytest-benchmark>=4.0,<5.0"]
+all = ["fastmcp==2.14.5", "onnxruntime==1.24.2", "tokenizers==0.22.2", "sentence-transformers==5.2.3"]
 
 [project.urls]
 Homepage = "https://github.com/star-ga/mind-mem"

--- a/scripts/backup_restore.py
+++ b/scripts/backup_restore.py
@@ -69,6 +69,11 @@ class WAL:
 
         Returns the WAL entry ID (used to commit/rollback).
         """
+        resolved = os.path.realpath(target_path)
+        ws_real = os.path.realpath(self.workspace)
+        if not resolved.startswith(ws_real + os.sep) and resolved != ws_real:
+            raise ValueError(f"WAL.begin: target_path escapes workspace: {target_path}")
+
         ts = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
         WAL._counter += 1
         entry_id = f"wal-{ts}-{WAL._counter}"

--- a/scripts/block_parser.py
+++ b/scripts/block_parser.py
@@ -72,7 +72,7 @@ _NEGATION_RE = re.compile(
 
 
 # Nested dict fields recognized in ConstraintSignature parsing
-DICT_FIELDS = {"scope", "axis", "lifecycle"}
+_DICT_FIELDS = {"scope", "axis", "lifecycle"}
 
 
 def parse_blocks(text: str) -> list[dict]:
@@ -173,7 +173,7 @@ def parse_blocks(text: str) -> list[dict]:
 
                 # Nested dict sub-fields at 4-space indent (scope, axis, lifecycle)
                 nested_kv = re.match(r"^    ([a-z_]+):\s+(.+)$", line)
-                if nested_kv and current_sig_field in DICT_FIELDS:
+                if nested_kv and current_sig_field in _DICT_FIELDS:
                     parent = current_sig_field
                     if not isinstance(current_sig.get(parent), dict):
                         current_sig[parent] = {}
@@ -188,7 +188,7 @@ def parse_blocks(text: str) -> list[dict]:
 
                 # Nested sub-sub-fields at 6-space indent (e.g. scope.time)
                 time_kv = re.match(r"^      ([a-z_]+):\s+(.+)$", line)
-                if time_kv and current_sig_field in DICT_FIELDS:
+                if time_kv and current_sig_field in _DICT_FIELDS:
                     parent = current_sig_field
                     if not isinstance(current_sig.get(parent), dict):
                         current_sig[parent] = {}
@@ -585,7 +585,7 @@ def chunk_block(
     text_value = ""
     for field in ("Statement", "Description", "Summary", "Title"):
         val = block.get(field, "")
-        if isinstance(val, str) and len(val) > text_value.__len__():
+        if isinstance(val, str) and len(val) > len(text_value):
             text_field = field
             text_value = val
 
@@ -659,21 +659,16 @@ def get_by_id(blocks: list[dict], block_id: str) -> dict | None:
 def extract_refs(blocks: list[dict]) -> set[str]:
     """Extract all cross-reference IDs from block fields."""
     refs = set()
-    pattern = re.compile(
-        r"\b(D-\d{8}-\d{3}|T-\d{8}-\d{3}|INC-\d{8}-[a-z0-9-]+"
-        r"|PRJ-[a-z0-9-]+|PER-[a-z0-9-]+|TOOL-[a-z0-9-]+"
-        r"|C-\d{8}-\d{3}|DREF-\d{8}-\d{3}|I-\d{8}-\d{3})\b"
-    )
     for block in blocks:
         for key, val in block.items():
             if key.startswith("_"):
                 continue
             if isinstance(val, str):
-                refs.update(pattern.findall(val))
+                refs.update(_ENTITY_ID_RE.findall(val))
             elif isinstance(val, list):
                 for item in val:
                     if isinstance(item, str):
-                        refs.update(pattern.findall(item))
+                        refs.update(_ENTITY_ID_RE.findall(item))
     return refs
 
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -28,7 +28,7 @@ def get_pyproject_version() -> str | None:
             return data.get("project", {}).get("version")
         # Regex fallback for Python <3.11 (no tomllib)
         content = Path("pyproject.toml").read_text()
-        m = re.search(r'version\s*=\s*"([^"]+)"', content)
+        m = re.search(r'^\[project\].*?^version\s*=\s*"([^"]+)"', content, re.MULTILINE | re.DOTALL)
         return m.group(1) if m else None
     except FileNotFoundError:
         return None

--- a/scripts/compaction.py
+++ b/scripts/compaction.py
@@ -196,14 +196,15 @@ def cleanup_daily_logs(ws: str, days: int = 180, dry_run: bool = False) -> list[
             cleaned.append(f"[dry-run] Would archive {fname} -> archive-{year}.md")
             continue
 
-        # Append to yearly archive
-        with open(log_path, "r", encoding="utf-8") as f:
-            content = f.read()
+        # Append to yearly archive (under lock to prevent races)
+        with FileLock(log_path):
+            with open(log_path, "r", encoding="utf-8") as f:
+                content = f.read()
 
-        with open(archive_path, "a", encoding="utf-8") as f:
-            f.write(f"\n# {date_str}\n\n{content}\n---\n")
+            with open(archive_path, "a", encoding="utf-8") as f:
+                f.write(f"\n# {date_str}\n\n{content}\n---\n")
 
-        os.remove(log_path)
+            os.remove(log_path)
         cleaned.append(f"Archived {fname} -> archive-{year}.md")
 
     return cleaned

--- a/scripts/extractor.py
+++ b/scripts/extractor.py
@@ -213,6 +213,15 @@ _THIRD_PERSON_RE = re.compile(
 )
 
 # D.3: Relation words for possessive extraction
+_SEM_LABELS = {
+    "FACT": "identity description who is",
+    "EVENT": "activity event did went action",
+    "PREFERENCE": "preference interest hobby likes enjoys",
+    "RELATION": "relationship connection knows",
+    "NEGATION": "never not does not",
+    "PLAN": "goal intention plan wants future",
+}
+
 _RELATION_WORDS = frozenset(
     {
         "brother",
@@ -670,14 +679,6 @@ def format_as_blocks(
         # Semantic labels: BM25 vocabulary bridge for generic queries.
         # Embedded in Statement (3.0x weight) instead of Context (0.5x)
         # so "What is Caroline's identity?" strongly matches fact cards.
-        _SEM_LABELS = {
-            "FACT": "identity description who is",
-            "EVENT": "activity event did went action",
-            "PREFERENCE": "preference interest hobby likes enjoys",
-            "RELATION": "relationship connection knows",
-            "NEGATION": "never not does not",
-            "PLAN": "goal intention plan wants future",
-        }
         sem = _SEM_LABELS.get(card_type, "")
         prefix = f"({sem}) " if sem else ""
 

--- a/scripts/mind_ffi.py
+++ b/scripts/mind_ffi.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 import ctypes
 import os
+import re as _re
 from pathlib import Path
-from typing import Optional
 
 from .observability import get_logger
 
@@ -83,7 +83,7 @@ class MindMemKernel:
             pass  # Fallback to pure Python
     """
 
-    def __init__(self, lib_path: Optional[str] = None):
+    def __init__(self, lib_path: str | None = None):
         """Load the compiled MIND shared library.
 
         Raises:
@@ -161,7 +161,7 @@ class MindMemKernel:
             pass  # Unprotected build (dev/CI fallback)
 
         # Version check: compare .so version against Python __version__
-        self._so_version: Optional[str] = None
+        self._so_version: str | None = None
         try:
             self._lib.mindmem_get_version.argtypes = []
             self._lib.mindmem_get_version.restype = ctypes.c_char_p
@@ -176,7 +176,7 @@ class MindMemKernel:
         """Return True if the loaded library includes runtime protection."""
         return self._protected
 
-    def so_version(self) -> Optional[str]:
+    def so_version(self) -> str | None:
         """Return the version string reported by the .so, or None."""
         return self._so_version
 
@@ -416,11 +416,11 @@ class MindMemKernel:
 
 # --- Module-level singleton ---
 
-_kernel: Optional[MindMemKernel] = None
+_kernel: MindMemKernel | None = None
 _USE_MIND: bool = False
 
 
-def get_kernel() -> Optional[MindMemKernel]:
+def get_kernel() -> MindMemKernel | None:
     """Get or create singleton kernel. Returns None if unavailable."""
     global _kernel, _USE_MIND
     if _kernel is not None:
@@ -532,8 +532,6 @@ def get_kernel_param(config: dict, section: str, key: str, default=None):
 
 # --- INI-style .mind config parsing ---
 # .mind files use a simple [section] / key = value format for tuning params.
-
-import re as _re  # noqa: E402
 
 
 def _parse_value(raw: str):

--- a/scripts/retrieval_graph.py
+++ b/scripts/retrieval_graph.py
@@ -179,7 +179,8 @@ def propagate_scores(
     try:
         conn = _connect(workspace)
         conn.executescript(_SCHEMA_SQL)
-    except Exception:
+    except Exception as exc:
+        _log.debug("propagate_scores_failed", error=str(exc))
         if conn:
             conn.close()
         return dict(initial_scores)
@@ -193,7 +194,8 @@ def propagate_scores(
             m1, m2, w = row["mem1_id"], row["mem2_id"], row["weight"]
             adj.setdefault(m1, []).append((m2, w))
             adj.setdefault(m2, []).append((m1, w))
-    except Exception:
+    except Exception as exc:
+        _log.debug("propagate_scores_failed", error=str(exc))
         return dict(initial_scores)
     finally:
         if conn:

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import threading
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from .observability import get_logger
 

--- a/tests/test_agent_id_filter.py
+++ b/tests/test_agent_id_filter.py
@@ -10,30 +10,41 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "agent_test.md")
     with open(blocks_md, "w") as f:
         f.write("[AGT-001]\nType: Decision\nStatement: Agent-specific decision\n\n")
-    return ws
+    return ws, td
 
 
 def test_agent_id_none():
     """None agent_id returns all results."""
-    ws = _make_workspace()
-    results = recall(ws, "decision", limit=10, agent_id=None)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decision", limit=10, agent_id=None)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_agent_id_string():
     """String agent_id doesn't crash."""
-    ws = _make_workspace()
-    results = recall(ws, "decision", limit=10, agent_id="test-agent")
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decision", limit=10, agent_id="test-agent")
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_agent_id_empty():
     """Empty agent_id behaves like None."""
-    ws = _make_workspace()
-    results = recall(ws, "decision", limit=10, agent_id="")
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decision", limit=10, agent_id="")
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_allow_decompose.py
+++ b/tests/test_allow_decompose.py
@@ -10,24 +10,32 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "decompose_test.md")
     with open(blocks_md, "w") as f:
         f.write("[AD-001]\nType: Decision\nStatement: Decomposition test alpha\n\n")
         f.write("[AD-002]\nType: Decision\nStatement: Decomposition test beta\n\n")
-    return ws
+    return ws, td
 
 
 def test_allow_decompose_true():
     """_allow_decompose=True works."""
-    ws = _make_workspace()
-    results = recall(ws, "decomposition test alpha and beta", limit=5, _allow_decompose=True)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decomposition test alpha and beta", limit=5, _allow_decompose=True)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_allow_decompose_false():
     """_allow_decompose=False works."""
-    ws = _make_workspace()
-    results = recall(ws, "decomposition test alpha and beta", limit=5, _allow_decompose=False)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decomposition test alpha and beta", limit=5, _allow_decompose=False)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_block_parser_multifile.py
+++ b/tests/test_block_parser_multifile.py
@@ -9,30 +9,30 @@ from scripts.block_parser import parse_file
 
 
 def test_parse_multiple_files():
-    d = tempfile.mkdtemp()
-    for i in range(3):
-        p = os.path.join(d, f"file{i}.md")
-        with open(p, "w") as f:
-            f.write(f"[MF-{i:03d}]\nType: Decision\nStatement: File {i}\n\n")
-    for i in range(3):
-        blocks = parse_file(os.path.join(d, f"file{i}.md"))
-        assert len(blocks) >= 1
+    with tempfile.TemporaryDirectory() as d:
+        for i in range(3):
+            p = os.path.join(d, f"file{i}.md")
+            with open(p, "w") as f:
+                f.write(f"[MF-{i:03d}]\nType: Decision\nStatement: File {i}\n\n")
+        for i in range(3):
+            blocks = parse_file(os.path.join(d, f"file{i}.md"))
+            assert len(blocks) >= 1
 
 
 def test_large_file_parse():
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-        for i in range(50):
-            f.write(f"[LF-{i:03d}]\nType: Decision\nStatement: Block {i}\n\n")
-        path = f.name
-    blocks = parse_file(path)
-    assert len(blocks) == 50
-    os.unlink(path)
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "large.md")
+        with open(path, "w") as f:
+            for i in range(50):
+                f.write(f"[LF-{i:03d}]\nType: Decision\nStatement: Block {i}\n\n")
+        blocks = parse_file(path)
+        assert len(blocks) == 50
 
 
 def test_mixed_content():
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-        f.write("# Header\nSome text\n\n[MX-001]\nType: Decision\nStatement: In mixed file\n\nMore text\n")
-        path = f.name
-    blocks = parse_file(path)
-    assert len(blocks) >= 1
-    os.unlink(path)
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "mixed.md")
+        with open(path, "w") as f:
+            f.write("# Header\nSome text\n\n[MX-001]\nType: Decision\nStatement: In mixed file\n\nMore text\n")
+        blocks = parse_file(path)
+        assert len(blocks) >= 1

--- a/tests/test_block_types.py
+++ b/tests/test_block_types.py
@@ -10,7 +10,9 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     for dir_name, block_type, prefix in [
         ("decisions", "Decision", "DEC"),
@@ -20,32 +22,44 @@ def _make_workspace():
         path = os.path.join(ws, dir_name, "types.md")
         with open(path, "w") as f:
             f.write(f"[{prefix}-001]\nType: {block_type}\nStatement: Type test {block_type}\n\n")
-    return ws
+    return ws, td
 
 
 def test_recall_decision_type():
     """Recall returns Decision type blocks."""
-    ws = _make_workspace()
-    results = recall(ws, "type test decision", limit=10)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "type test decision", limit=10)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_recall_task_type():
     """Recall returns Task type blocks."""
-    ws = _make_workspace()
-    results = recall(ws, "type test task", limit=10)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "type test task", limit=10)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_recall_entity_type():
     """Recall returns Entity type blocks."""
-    ws = _make_workspace()
-    results = recall(ws, "type test entity", limit=10)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "type test entity", limit=10)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_recall_all_types():
     """Recall searches across all block types."""
-    ws = _make_workspace()
-    results = recall(ws, "type test", limit=10)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "type test", limit=10)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_delete_memory.py
+++ b/tests/test_delete_memory.py
@@ -15,13 +15,15 @@ from scripts.init_workspace import init  # noqa: E402
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "delete_test.md")
     with open(blocks_md, "w") as f:
         f.write("[DEL-001]\nType: Decision\nStatement: To be deleted\n\n")
         f.write("[DEL-002]\nType: Decision\nStatement: To keep\n\n")
-    return ws
+    return ws, td
 
 
 def test_delete_importable():
@@ -31,13 +33,19 @@ def test_delete_importable():
 
 def test_delete_existing_block():
     """Deleting an existing block succeeds."""
-    ws = _make_workspace()
-    result = delete_block(ws, "DEL-001")
-    assert result is not None
+    ws, td = _make_workspace()
+    try:
+        result = delete_block(ws, "DEL-001")
+        assert result is not None
+    finally:
+        td.cleanup()
 
 
 def test_delete_nonexistent_block():
     """Deleting non-existent block handles gracefully."""
-    ws = _make_workspace()
-    result = delete_block(ws, "NONEXIST-999")
-    assert isinstance(result, (dict, bool, type(None)))
+    ws, td = _make_workspace()
+    try:
+        result = delete_block(ws, "NONEXIST-999")
+        assert isinstance(result, (dict, bool, type(None)))
+    finally:
+        td.cleanup()

--- a/tests/test_error_paths.py
+++ b/tests/test_error_paths.py
@@ -452,14 +452,9 @@ class TestBadQueryTypes(unittest.TestCase):
             self.assertIsInstance(results, list)
 
     def test_tokenize_none_input(self):
-        """tokenize with non-string input should handle gracefully."""
-        # tokenize expects a string; passing None should raise or return empty
-        try:
-            result = tokenize(None)
-            # If it doesn't raise, it should return a list
-            self.assertIsInstance(result, list)
-        except (TypeError, AttributeError):
-            pass  # Expected — tokenize may not guard against None
+        """tokenize with non-string input should raise."""
+        with self.assertRaises((TypeError, AttributeError)):
+            tokenize(None)
 
     def test_tokenize_very_long_input(self):
         """tokenize with very long input should not hang."""

--- a/tests/test_export_memory.py
+++ b/tests/test_export_memory.py
@@ -16,28 +16,36 @@ from scripts.init_workspace import init  # noqa: E402
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "export_test.md")
     with open(blocks_md, "w") as f:
         f.write("[EXP-001]\nType: Decision\nStatement: Exportable decision\n\n")
         f.write("[EXP-002]\nType: Decision\nStatement: Another exportable\n\n")
-    return ws
+    return ws, td
 
 
 def test_export_produces_output():
     """Export produces non-empty output."""
-    ws = _make_workspace()
-    result = export_memory(ws)
-    assert result is not None
-    assert len(result) > 0
+    ws, td = _make_workspace()
+    try:
+        result = export_memory(ws)
+        assert result is not None
+        assert len(result) > 0
+    finally:
+        td.cleanup()
 
 
 def test_export_format_jsonl():
     """Export produces valid JSONL."""
-    ws = _make_workspace()
-    result = export_memory(ws, format="jsonl")
-    if isinstance(result, str):
-        for line in result.strip().split("\n"):
-            if line:
-                json.loads(line)  # Should not raise
+    ws, td = _make_workspace()
+    try:
+        result = export_memory(ws, format="jsonl")
+        if isinstance(result, str):
+            for line in result.strip().split("\n"):
+                if line:
+                    json.loads(line)  # Should not raise
+    finally:
+        td.cleanup()

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -11,52 +11,69 @@ from scripts.init_workspace import init
 
 def _make_workspace():
     """Create a test workspace with sample blocks."""
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "hybrid.md")
     with open(blocks_md, "w") as f:
         f.write("[HYB-001]\nType: Decision\nStatement: Use BM25 for text retrieval\n\n")
         f.write("[HYB-002]\nType: Decision\nStatement: Vector search for semantic matching\n\n")
         f.write("[HYB-003]\nType: Decision\nStatement: RRF fusion combines both scores\n\n")
-    return ws
+    return ws, td
 
 
 def test_recall_returns_list():
     """Recall always returns a list."""
-    ws = _make_workspace()
-    results = recall(ws, "text retrieval", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "text retrieval", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_recall_respects_limit():
     """Results count doesn't exceed limit."""
-    ws = _make_workspace()
-    results = recall(ws, "decision", limit=2)
-    assert len(results) <= 2
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decision", limit=2)
+        assert len(results) <= 2
+    finally:
+        td.cleanup()
 
 
 def test_recall_results_have_id():
     """Each result has an id field."""
-    ws = _make_workspace()
-    results = recall(ws, "BM25 retrieval", limit=5)
-    for r in results:
-        assert "id" in r or "block_id" in r or "ID" in r.get("raw", {})
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "BM25 retrieval", limit=5)
+        for r in results:
+            assert "id" in r or "block_id" in r or "ID" in r.get("raw", {})
+    finally:
+        td.cleanup()
 
 
 def test_recall_relevance():
     """More relevant results rank higher."""
-    ws = _make_workspace()
-    results = recall(ws, "BM25 text retrieval", limit=5)
-    if len(results) >= 2:
-        # First result should have higher or equal score
-        scores = [r.get("score", 0) for r in results]
-        assert scores == sorted(scores, reverse=True)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "BM25 text retrieval", limit=5)
+        if len(results) >= 2:
+            # First result should have higher or equal score
+            scores = [r.get("score", 0) for r in results]
+            assert scores == sorted(scores, reverse=True)
+    finally:
+        td.cleanup()
 
 
 def test_recall_no_duplicates():
     """No duplicate block IDs in results."""
-    ws = _make_workspace()
-    results = recall(ws, "decision retrieval", limit=10)
-    ids = [r.get("id") or r.get("block_id") for r in results]
-    ids = [i for i in ids if i is not None]
-    assert len(ids) == len(set(ids))
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decision retrieval", limit=10)
+        ids = [r.get("id") or r.get("block_id") for r in results]
+        ids = [i for i in ids if i is not None]
+        assert len(ids) == len(set(ids))
+    finally:
+        td.cleanup()

--- a/tests/test_index_stats.py
+++ b/tests/test_index_stats.py
@@ -21,19 +21,23 @@ def test_index_stats_importable():
 
 def test_index_stats_empty_workspace():
     """Empty workspace returns valid stats."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    stats = get_index_stats(ws)
-    assert isinstance(stats, dict)
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        stats = get_index_stats(ws)
+        assert isinstance(stats, dict)
 
 
 def test_index_stats_with_blocks():
     """Workspace with blocks reports counts."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    blocks_md = os.path.join(ws, "decisions", "stats_test.md")
-    with open(blocks_md, "w") as f:
-        for i in range(10):
-            f.write(f"[STAT-{i:03d}]\nType: Decision\nStatement: Test {i}\n\n")
-    stats = get_index_stats(ws)
-    assert isinstance(stats, dict)
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        blocks_md = os.path.join(ws, "decisions", "stats_test.md")
+        with open(blocks_md, "w") as f:
+            for i in range(10):
+                f.write(f"[STAT-{i:03d}]\nType: Decision\nStatement: Test {i}\n\n")
+        stats = get_index_stats(ws)
+        assert isinstance(stats, dict)

--- a/tests/test_memory_evolution.py
+++ b/tests/test_memory_evolution.py
@@ -15,9 +15,11 @@ from scripts.init_workspace import init  # noqa: E402
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
-    return ws
+    return ws, td
 
 
 def test_evolution_tracking_importable():
@@ -27,16 +29,22 @@ def test_evolution_tracking_importable():
 
 def test_evolution_empty_workspace():
     """Evolution tracking on empty workspace doesn't crash."""
-    ws = _make_workspace()
-    result = track_evolution(ws, "NONEXIST-001")
-    assert isinstance(result, (dict, list, type(None)))
+    ws, td = _make_workspace()
+    try:
+        result = track_evolution(ws, "NONEXIST-001")
+        assert isinstance(result, (dict, list, type(None)))
+    finally:
+        td.cleanup()
 
 
 def test_evolution_returns_history():
     """Evolution tracking returns history list."""
-    ws = _make_workspace()
-    blocks_md = os.path.join(ws, "decisions", "evo.md")
-    with open(blocks_md, "w") as f:
-        f.write("[EVO-001]\nType: Decision\nStatement: Original\n\n")
-    result = track_evolution(ws, "EVO-001")
-    assert isinstance(result, (dict, list, type(None)))
+    ws, td = _make_workspace()
+    try:
+        blocks_md = os.path.join(ws, "decisions", "evo.md")
+        with open(blocks_md, "w") as f:
+            f.write("[EVO-001]\nType: Decision\nStatement: Original\n\n")
+        result = track_evolution(ws, "EVO-001")
+        assert isinstance(result, (dict, list, type(None)))
+    finally:
+        td.cleanup()

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -15,12 +15,14 @@ from scripts.init_workspace import init  # noqa: E402
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "prefetch_test.md")
     with open(blocks_md, "w") as f:
         f.write("[PF-001]\nType: Decision\nStatement: Prefetch test block\n\n")
-    return ws
+    return ws, td
 
 
 def test_prefetch_importable():
@@ -30,13 +32,19 @@ def test_prefetch_importable():
 
 def test_prefetch_with_signals():
     """Prefetch with context signals returns results."""
-    ws = _make_workspace()
-    result = prefetch(ws, signals={"recent_queries": ["test"]})
-    assert isinstance(result, (list, dict))
+    ws, td = _make_workspace()
+    try:
+        result = prefetch(ws, signals={"recent_queries": ["test"]})
+        assert isinstance(result, (list, dict))
+    finally:
+        td.cleanup()
 
 
 def test_prefetch_empty_signals():
     """Prefetch with no signals returns something."""
-    ws = _make_workspace()
-    result = prefetch(ws, signals={})
-    assert isinstance(result, (list, dict, type(None)))
+    ws, td = _make_workspace()
+    try:
+        result = prefetch(ws, signals={})
+        assert isinstance(result, (list, dict, type(None)))
+    finally:
+        td.cleanup()

--- a/tests/test_recall_concurrent.py
+++ b/tests/test_recall_concurrent.py
@@ -11,38 +11,46 @@ from scripts.init_workspace import init
 
 
 def _ws():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     p = os.path.join(ws, "decisions", "conc.md")
     with open(p, "w") as f:
         for i in range(10):
             f.write(f"[CC-{i:03d}]\nType: Decision\nStatement: Concurrent test {i}\n\n")
-    return ws
+    return ws, td
 
 
 def test_sequential_recalls():
-    ws = _ws()
-    for _ in range(5):
-        r = recall(ws, "concurrent test", limit=5)
-        assert isinstance(r, list)
+    ws, td = _ws()
+    try:
+        for _ in range(5):
+            r = recall(ws, "concurrent test", limit=5)
+            assert isinstance(r, list)
+    finally:
+        td.cleanup()
 
 
 def test_threaded_recalls():
-    ws = _ws()
-    results = []
-    errors = []
+    ws, td = _ws()
+    try:
+        results = []
+        errors = []
 
-    def worker():
-        try:
-            r = recall(ws, "concurrent test", limit=3)
-            results.append(r)
-        except Exception as e:
-            errors.append(e)
+        def worker():
+            try:
+                r = recall(ws, "concurrent test", limit=3)
+                results.append(r)
+            except Exception as e:
+                errors.append(e)
 
-    threads = [threading.Thread(target=worker) for _ in range(4)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join(timeout=30)
-    assert len(errors) == 0
-    assert len(results) == 4
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        assert len(errors) == 0
+        assert len(results) == 4
+    finally:
+        td.cleanup()

--- a/tests/test_recall_context_field.py
+++ b/tests/test_recall_context_field.py
@@ -10,20 +10,30 @@ from scripts.init_workspace import init
 
 
 def _ws():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     p = os.path.join(ws, "decisions", "ctx.md")
     with open(p, "w") as f:
         f.write("[CTX-001]\nType: Decision\nStatement: Main content\nContext: During sprint planning\n\n")
         f.write("[CTX-002]\nType: Decision\nStatement: Other content\nContext: During code review\n\n")
-    return ws
+    return ws, td
 
 
 def test_context_field_search():
-    results = recall(_ws(), "sprint planning", limit=5)
-    assert isinstance(results, list)
+    ws, td = _ws()
+    try:
+        results = recall(ws, "sprint planning", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_context_field_code_review():
-    results = recall(_ws(), "code review", limit=5)
-    assert isinstance(results, list)
+    ws, td = _ws()
+    try:
+        results = recall(ws, "code review", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_recall_date_field.py
+++ b/tests/test_recall_date_field.py
@@ -10,28 +10,39 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     path = os.path.join(ws, "decisions", "dated.md")
     with open(path, "w") as f:
         f.write("[DT-001]\nType: Decision\nStatement: Recent decision\nDate: 2026-02-24\n\n")
         f.write("[DT-002]\nType: Decision\nStatement: Old decision\nDate: 2025-01-01\n\n")
-    return ws
+    return ws, td
 
 
 def test_dated_blocks_found():
-    ws = _make_workspace()
-    results = recall(ws, "decision", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "decision", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_recent_date_search():
-    ws = _make_workspace()
-    results = recall(ws, "recent decision", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "recent decision", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_old_date_search():
-    ws = _make_workspace()
-    results = recall(ws, "old decision", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "old decision", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_recall_empty_query_types.py
+++ b/tests/test_recall_empty_query_types.py
@@ -10,30 +10,48 @@ from scripts.init_workspace import init
 
 
 def _ws():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     p = os.path.join(ws, "decisions", "eq.md")
     with open(p, "w") as f:
         f.write("[EQ-001]\nType: Decision\nStatement: Test block\n\n")
-    return ws
+    return ws, td
 
 
 def test_none_like_query():
-    results = recall(_ws(), "   \t\n  ", limit=5)
-    assert results == []
+    ws, td = _ws()
+    try:
+        results = recall(ws, "   \t\n  ", limit=5)
+        assert results == []
+    finally:
+        td.cleanup()
 
 
 def test_single_stopword():
-    results = recall(_ws(), "the", limit=5)
-    assert isinstance(results, list)
+    ws, td = _ws()
+    try:
+        results = recall(ws, "the", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_all_stopwords():
-    results = recall(_ws(), "the a an is was", limit=5)
-    assert isinstance(results, list)
-    assert len(results) == 0
+    ws, td = _ws()
+    try:
+        results = recall(ws, "the a an is was", limit=5)
+        assert isinstance(results, list)
+        assert len(results) == 0
+    finally:
+        td.cleanup()
 
 
 def test_punctuation_only():
-    results = recall(_ws(), "... !!! ???", limit=5)
-    assert isinstance(results, list)
+    ws, td = _ws()
+    try:
+        results = recall(ws, "... !!! ???", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_recall_large_workspace.py
+++ b/tests/test_recall_large_workspace.py
@@ -11,32 +11,43 @@ from scripts.init_workspace import init
 
 
 def _ws(n=100):
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     p = os.path.join(ws, "decisions", "large.md")
     with open(p, "w") as f:
         for i in range(n):
             f.write(f"[LG-{i:04d}]\nType: Decision\n")
             f.write(f"Statement: Large workspace block {i} about topic {chr(65 + i % 26)}\n\n")
-    return ws
+    return ws, td
 
 
 def test_100_blocks():
-    ws = _ws(100)
-    results = recall(ws, "large workspace block", limit=10)
-    assert isinstance(results, list)
-    assert len(results) <= 10
+    ws, td = _ws(100)
+    try:
+        results = recall(ws, "large workspace block", limit=10)
+        assert isinstance(results, list)
+        assert len(results) <= 10
+    finally:
+        td.cleanup()
 
 
 def test_recall_completes_in_time():
-    ws = _ws(100)
-    start = time.perf_counter()
-    recall(ws, "workspace block topic", limit=10)
-    elapsed = (time.perf_counter() - start) * 1000
-    assert elapsed < 5000, f"Recall took {elapsed:.0f}ms"
+    ws, td = _ws(100)
+    try:
+        start = time.perf_counter()
+        recall(ws, "workspace block topic", limit=10)
+        elapsed = (time.perf_counter() - start) * 1000
+        assert elapsed < 5000, f"Recall took {elapsed:.0f}ms"
+    finally:
+        td.cleanup()
 
 
 def test_limit_respected_large():
-    ws = _ws(100)
-    results = recall(ws, "block", limit=5)
-    assert len(results) <= 5
+    ws, td = _ws(100)
+    try:
+        results = recall(ws, "block", limit=5)
+        assert len(results) <= 5
+    finally:
+        td.cleanup()

--- a/tests/test_recall_references.py
+++ b/tests/test_recall_references.py
@@ -10,22 +10,30 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     path = os.path.join(ws, "decisions", "refs.md")
     with open(path, "w") as f:
         f.write("[REF-001]\nType: Decision\nStatement: Primary decision\nReferences: REF-002\n\n")
         f.write("[REF-002]\nType: Decision\nStatement: Referenced decision\nReferences: REF-001\n\n")
-    return ws
+    return ws, td
 
 
 def test_reference_search():
-    ws = _make_workspace()
-    results = recall(ws, "primary decision", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "primary decision", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_referenced_block():
-    ws = _make_workspace()
-    results = recall(ws, "referenced decision", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "referenced decision", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_recall_source_field.py
+++ b/tests/test_recall_source_field.py
@@ -10,25 +10,33 @@ from scripts.init_workspace import init
 
 
 def _ws():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     p = os.path.join(ws, "decisions", "src_test.md")
     with open(p, "w") as f:
         f.write("[SRC-001]\nType: Decision\nStatement: Source field test\n\n")
-    return ws
+    return ws, td
 
 
 def test_results_have_source():
-    ws = _ws()
-    results = recall(ws, "source field test", limit=5)
-    if results:
-        r = results[0]
-        assert "source" in r or "file" in r or "_source" in r or "raw" in r
+    ws, td = _ws()
+    try:
+        results = recall(ws, "source field test", limit=5)
+        if results:
+            r = results[0]
+            assert "source" in r or "file" in r or "_source" in r or "raw" in r
+    finally:
+        td.cleanup()
 
 
 def test_source_is_string():
-    ws = _ws()
-    results = recall(ws, "source field test", limit=5)
-    for r in results:
-        src = r.get("source") or r.get("file") or r.get("_source", "")
-        assert isinstance(src, str)
+    ws, td = _ws()
+    try:
+        results = recall(ws, "source field test", limit=5)
+        for r in results:
+            src = r.get("source") or r.get("file") or r.get("_source", "")
+            assert isinstance(src, str)
+    finally:
+        td.cleanup()

--- a/tests/test_recall_speaker.py
+++ b/tests/test_recall_speaker.py
@@ -10,22 +10,30 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     path = os.path.join(ws, "decisions", "speaker.md")
     with open(path, "w") as f:
         f.write("[SPK-001]\nType: Decision\nStatement: User said this\nSpeaker: alice\n\n")
         f.write("[SPK-002]\nType: Decision\nStatement: System generated\nSpeaker: system\n\n")
-    return ws
+    return ws, td
 
 
 def test_speaker_search():
-    ws = _make_workspace()
-    results = recall(ws, "alice said", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "alice said", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_system_speaker():
-    ws = _make_workspace()
-    results = recall(ws, "system generated", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "system generated", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_recall_tags.py
+++ b/tests/test_recall_tags.py
@@ -10,28 +10,39 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     path = os.path.join(ws, "decisions", "tags.md")
     with open(path, "w") as f:
         f.write("[TAG-001]\nType: Decision\nStatement: Tagged decision\nTags: api, design\n\n")
         f.write("[TAG-002]\nType: Decision\nStatement: Another tagged\nTags: performance, optimization\n\n")
-    return ws
+    return ws, td
 
 
 def test_tag_search():
-    ws = _make_workspace()
-    results = recall(ws, "api design", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "api design", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_tag_content_search():
-    ws = _make_workspace()
-    results = recall(ws, "performance optimization", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "performance optimization", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_mixed_tag_statement():
-    ws = _make_workspace()
-    results = recall(ws, "tagged decision api", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "tagged decision api", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_rerank_debug.py
+++ b/tests/test_rerank_debug.py
@@ -10,31 +10,42 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "rerank_test.md")
     with open(blocks_md, "w") as f:
         for i in range(5):
             f.write(f"[RR-{i:03d}]\nType: Decision\nStatement: Rerank test {i}\n\n")
-    return ws
+    return ws, td
 
 
 def test_rerank_enabled():
     """Reranking enabled doesn't crash."""
-    ws = _make_workspace()
-    results = recall(ws, "rerank test", limit=5, rerank=True)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "rerank test", limit=5, rerank=True)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_rerank_disabled():
     """Reranking disabled returns results."""
-    ws = _make_workspace()
-    results = recall(ws, "rerank test", limit=5, rerank=False)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "rerank test", limit=5, rerank=False)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_rerank_debug_mode():
     """Debug mode doesn't crash."""
-    ws = _make_workspace()
-    results = recall(ws, "rerank test", limit=5, rerank=True, rerank_debug=True)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "rerank test", limit=5, rerank=True, rerank_debug=True)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_scan_engine.py
+++ b/tests/test_scan_engine.py
@@ -15,25 +15,32 @@ from scripts.init_workspace import init  # noqa: E402
 
 
 def _make_workspace_with_blocks():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "scan_test.md")
     with open(blocks_md, "w") as f:
         f.write("[SCAN-001]\nType: Decision\nStatement: First decision\nStatus: Active\n\n")
         f.write("[SCAN-002]\nType: Decision\nStatement: Contradicts first\nStatus: Active\n\n")
-    return ws
+    return ws, td
 
 
 def test_scan_workspace_no_crash():
     """Scanning a valid workspace doesn't crash."""
-    ws = _make_workspace_with_blocks()
-    result = scan(ws)
-    assert isinstance(result, (dict, list))
+    ws, td = _make_workspace_with_blocks()
+    try:
+        result = scan(ws)
+        assert isinstance(result, (dict, list))
+    finally:
+        td.cleanup()
 
 
 def test_scan_empty_workspace():
     """Scanning empty workspace returns clean result."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    result = scan(ws)
-    assert isinstance(result, (dict, list))
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        result = scan(ws)
+        assert isinstance(result, (dict, list))

--- a/tests/test_wide_retrieval.py
+++ b/tests/test_wide_retrieval.py
@@ -10,31 +10,42 @@ from scripts.init_workspace import init
 
 
 def _make_workspace():
-    ws = tempfile.mkdtemp()
+    td = tempfile.TemporaryDirectory()
+    ws = os.path.join(td.name, "ws")
+    os.makedirs(ws)
     init(ws)
     blocks_md = os.path.join(ws, "decisions", "wide_test.md")
     with open(blocks_md, "w") as f:
         for i in range(20):
             f.write(f"[WD-{i:03d}]\nType: Decision\nStatement: Wide retrieval test {i}\n\n")
-    return ws
+    return ws, td
 
 
 def test_default_wide_k():
     """Default retrieve_wide_k works."""
-    ws = _make_workspace()
-    results = recall(ws, "wide retrieval", limit=5)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "wide retrieval", limit=5)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_small_wide_k():
     """Small retrieve_wide_k still returns results."""
-    ws = _make_workspace()
-    results = recall(ws, "wide retrieval", limit=5, retrieve_wide_k=10)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "wide retrieval", limit=5, retrieve_wide_k=10)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()
 
 
 def test_large_wide_k():
     """Large retrieve_wide_k doesn't crash."""
-    ws = _make_workspace()
-    results = recall(ws, "wide retrieval", limit=5, retrieve_wide_k=1000)
-    assert isinstance(results, list)
+    ws, td = _make_workspace()
+    try:
+        results = recall(ws, "wide retrieval", limit=5, retrieve_wide_k=1000)
+        assert isinstance(results, list)
+    finally:
+        td.cleanup()

--- a/tests/test_workspace_init.py
+++ b/tests/test_workspace_init.py
@@ -10,43 +10,52 @@ from scripts.init_workspace import init
 
 def test_init_creates_directories():
     """init() creates the expected directory structure."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    for d in ["decisions", "tasks", "entities", "memory", "intelligence", "summaries"]:
-        assert os.path.isdir(os.path.join(ws, d)), f"Missing directory: {d}"
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        for d in ["decisions", "tasks", "entities", "memory", "intelligence", "summaries"]:
+            assert os.path.isdir(os.path.join(ws, d)), f"Missing directory: {d}"
 
 
 def test_init_creates_memory_md():
     """init() creates MEMORY.md."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    assert os.path.isfile(os.path.join(ws, "MEMORY.md"))
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        assert os.path.isfile(os.path.join(ws, "MEMORY.md"))
 
 
 def test_init_idempotent():
     """Calling init() twice doesn't error."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    init(ws)  # Should not raise
-    assert os.path.isdir(os.path.join(ws, "decisions"))
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        init(ws)  # Should not raise
+        assert os.path.isdir(os.path.join(ws, "decisions"))
 
 
 def test_init_preserves_existing_files():
     """init() doesn't overwrite existing files."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    marker = os.path.join(ws, "decisions", "existing.md")
-    with open(marker, "w") as f:
-        f.write("keep me")
-    init(ws)
-    assert os.path.isfile(marker)
-    with open(marker) as f:
-        assert f.read() == "keep me"
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        marker = os.path.join(ws, "decisions", "existing.md")
+        with open(marker, "w") as f:
+            f.write("keep me")
+        init(ws)
+        assert os.path.isfile(marker)
+        with open(marker) as f:
+            assert f.read() == "keep me"
 
 
 def test_init_nested_path():
     """init() works with deeply nested paths."""
-    ws = os.path.join(tempfile.mkdtemp(), "a", "b", "c")
-    os.makedirs(ws)
-    init(ws)
-    assert os.path.isdir(os.path.join(ws, "decisions"))
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "a", "b", "c")
+        os.makedirs(ws)
+        init(ws)
+        assert os.path.isdir(os.path.join(ws, "decisions"))

--- a/tests/test_workspace_structure.py
+++ b/tests/test_workspace_structure.py
@@ -12,47 +12,57 @@ EXPECTED_DIRS = ["decisions", "tasks", "entities", "memory", "intelligence", "su
 
 def test_all_directories_created():
     """All expected directories are created."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    for d in EXPECTED_DIRS:
-        path = os.path.join(ws, d)
-        assert os.path.isdir(path), f"Missing: {d}"
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        for d in EXPECTED_DIRS:
+            path = os.path.join(ws, d)
+            assert os.path.isdir(path), f"Missing: {d}"
 
 
 def test_directories_are_writable():
     """All directories are writable."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    for d in EXPECTED_DIRS:
-        test_file = os.path.join(ws, d, "write_test.tmp")
-        with open(test_file, "w") as f:
-            f.write("test")
-        os.unlink(test_file)
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        for d in EXPECTED_DIRS:
+            test_file = os.path.join(ws, d, "write_test.tmp")
+            with open(test_file, "w") as f:
+                f.write("test")
+            os.unlink(test_file)
 
 
 def test_memory_md_exists():
     """MEMORY.md is created at workspace root."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    assert os.path.isfile(os.path.join(ws, "MEMORY.md"))
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        assert os.path.isfile(os.path.join(ws, "MEMORY.md"))
 
 
 def test_memory_md_has_content():
     """MEMORY.md has initial content."""
-    ws = tempfile.mkdtemp()
-    init(ws)
-    with open(os.path.join(ws, "MEMORY.md")) as f:
-        content = f.read()
-    assert len(content) > 0
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        init(ws)
+        with open(os.path.join(ws, "MEMORY.md")) as f:
+            content = f.read()
+        assert len(content) > 0
 
 
 def test_workspace_is_self_contained():
     """No files created outside workspace directory."""
-    ws = tempfile.mkdtemp()
-    parent = os.path.dirname(ws)
-    before = set(os.listdir(parent))
-    init(ws)
-    after = set(os.listdir(parent))
-    new_files = after - before
-    # Only the workspace dir itself should be present
-    assert len(new_files) <= 1
+    with tempfile.TemporaryDirectory() as td:
+        ws = os.path.join(td, "ws")
+        os.makedirs(ws)
+        parent = os.path.dirname(ws)
+        before = set(os.listdir(parent))
+        init(ws)
+        after = set(os.listdir(parent))
+        new_files = after - before
+        # Only the workspace dir itself should be present
+        assert len(new_files) <= 1


### PR DESCRIPTION
## Summary
- Fix all findings from 5-dimension re-audit (security, CI/CD, architecture, code quality, tests)
- 40 files changed across 4 workstreams executed in parallel

### Security (4 fixes)
- Remove dead `_resolve_scope()`, fix ACL docs for env-var scope model
- Add allow-list deny for unknown tools not in ADMIN/USER sets
- Add `FileLock` to `cleanup_daily_logs()` (was the only unprotected compaction func)
- Add workspace boundary validation to `WAL.begin()`

### CI/CD (8 fixes)
- Pin `pypa/gh-action-pypi-publish` and `claude-code-security-review` to commit SHA
- Update `release.yml` artifacts to `@v6`, add `permissions` to `docs.yml`
- Fix `[all]` extras to include `onnxruntime`/`tokenizers`
- Add `pytest-benchmark` extra for benchmark workflow
- Anchor `check_version.py` regex to `[project]` section
- Extract `MCP_SCHEMA_VERSION` constant (was hardcoded 38x)

### Code quality (8 fixes)
- Deduplicate `extract_refs()` regex with module-level `_ENTITY_ID_RE`
- Fix inconsistent imports in `mcp_server.py` (bare → `mind_mem.*`)
- Hoist `_SEM_LABELS` dict to module level in `extractor.py`
- Fix `__len__()` dunder call, rename `DICT_FIELDS` → `_DICT_FIELDS`
- Add logging to bare `except` blocks in `retrieval_graph.py`
- Modernize typing: `Optional` → `X | None`, `typing.Callable` → `collections.abc`

### Tests (25 fixes)
- Convert 24 test files from bare `mkdtemp()` to `TemporaryDirectory` cleanup
- Fix exception-swallowing `test_tokenize_none_input` to use `assertRaises`

## Test plan
- [x] 1828 tests pass, 6 skipped, 0 failures
- [x] `ruff check` clean
- [x] `ruff format` clean