### PR TITLE
fix(ci): no more SKIPPED — docker-scan concludes SUCCESS on no-Dockerfile PRs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -146,32 +146,43 @@ jobs:
         with:
           files: sbom.cdx.json
 
-  # ── Docker / Trivy image scan (only on Dockerfile changes) ───────────────────
+  # ── Docker / Trivy image scan (always runs; gates work at step level) ───────
+  # Job is unconditional so it concludes SUCCESS instead of SKIPPED on PRs
+  # that don't touch Dockerfile. Heavy steps (build + scan) gate on the
+  # diff check below.
   docker-scan:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.changed_files, 'Dockerfile'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 2  # need parent for `HEAD^` diff
 
       - name: Check if Dockerfile changed
         id: df_changed
         run: |
-          git diff --name-only ${{ github.event.before || 'HEAD^' }} HEAD \
-            | grep -qE 'Dockerfile|deploy/docker/' \
-            && echo "changed=true" >> "$GITHUB_OUTPUT" \
-            || echo "changed=false" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+            changed=$(git diff --name-only "$base" "$head" | grep -E 'Dockerfile|deploy/docker/' || true)
+          else
+            changed=$(git diff --name-only "${{ github.event.before || 'HEAD^' }}" HEAD | grep -E 'Dockerfile|deploy/docker/' || true)
+          fi
+          if [ -n "$changed" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Dockerfile change detected — running scan"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Dockerfile change — scan steps are no-ops, job will SUCCESS"
+          fi
 
       - name: Build Docker image
-        if: steps.df_changed.outputs.changed == 'true' || github.event_name == 'schedule'
+        if: steps.df_changed.outputs.changed == 'true'
         run: |
           docker build -t mind-mem:scan \
             -f ${DOCKERFILE:-Dockerfile} .
 
       - name: Run Trivy image scan
-        if: steps.df_changed.outputs.changed == 'true' || github.event_name == 'schedule'
+        if: steps.df_changed.outputs.changed == 'true'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           image-ref: mind-mem:scan
@@ -182,7 +193,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy SARIF
-        if: always() && (steps.df_changed.outputs.changed == 'true' || github.event_name == 'schedule')
+        if: always() && steps.df_changed.outputs.changed == 'true'
         uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162  # v4
         with:
           sarif_file: trivy-image.sarif

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind-mem`
-**Files:** 725 | **Est. tokens:** ~1,493,301
-**Generated:** 2026-05-04 00:18 UTC
+**Files:** 725 | **Est. tokens:** ~1,493,431
+**Generated:** 2026-05-04 02:03 UTC
 
 ## Token Budget Guide
 
@@ -37,7 +37,7 @@
 | `examples/` | 3 | ~1,201 |
 | `.github/` | 7 | ~4,109 |
 | `.github/ISSUE_TEMPLATE/` | 2 | ~179 |
-| `.github/workflows/` | 11 | ~8,275 |
+| `.github/workflows/` | 11 | ~8,405 |
 | `hooks/` | 3 | ~801 |
 | `hooks/openclaw/mind-mem/` | 2 | ~1,211 |
 | `intelligence/` | 1 | ~113 |
@@ -271,7 +271,7 @@
 - `label-sync.yml` (~112 tok, small) — name: Label Sync
 - `release.yml` (~1638 tok, huge) — name: Release
 - `security-review.yml` (~240 tok, medium) — name: Security Review
-- `security.yml` (~1764 tok, huge) — name: Supply-Chain Security
+- `security.yml` (~1894 tok, huge) — name: Supply-Chain Security
 - `stale.yml` (~241 tok, medium) — name: Stale Issues
 ### `hooks/`
 


### PR DESCRIPTION
Job-level `if:` made docker-scan SKIPPED on every PR that didn't touch a Dockerfile. Fix: always run the job, gate the heavy build+scan steps at step level on a proper PR-aware diff (base.sha vs head.sha). Result: SUCCESS when no Dockerfile change, real scan when there is one. No more SKIPPED in PR check rollups.