### PR TITLE
release(v3.9.0): MCP wrapping for walkthrough/persona + pipeline-hash helpers

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind-mem`
-**Files:** 725 | **Est. tokens:** ~1,493,431
-**Generated:** 2026-05-04 02:03 UTC
+**Files:** 729 | **Est. tokens:** ~1,502,449
+**Generated:** 2026-05-04 02:42 UTC
 
 ## Token Budget Guide
 
@@ -22,7 +22,7 @@
 
 | Directory | Files | Est. tokens |
 |-----------|-------|-------------|
-| `./` | 32 | ~84,446 |
+| `./` | 32 | ~85,230 |
 | `.agents/skills/mind-mem-development/` | 1 | ~456 |
 | `.arch-mind/` | 4 | ~1,100 |
 | `benchmarks/` | 26 | ~64,933 |
@@ -30,7 +30,7 @@
 | `deploy/docker/` | 1 | ~495 |
 | `deploy/edge/` | 2 | ~1,149 |
 | `deploy/grafana/` | 1 | ~1,145 |
-| `docs/` | 63 | ~100,581 |
+| `docs/` | 63 | ~100,645 |
 | `docs/adr/` | 2 | ~521 |
 | `docs/design/` | 2 | ~2,416 |
 | `docs/security-baselines/` | 1 | ~18,974 |
@@ -54,15 +54,15 @@
 | `skills/integrity-scan/` | 1 | ~376 |
 | `skills/memory-recall/` | 1 | ~549 |
 | `src/` | 1 | ~280 |
-| `src/mind_mem/` | 155 | ~534,366 |
+| `src/mind_mem/` | 155 | ~535,421 |
 | `src/mind_mem/api/` | 5 | ~15,697 |
-| `src/mind_mem/mcp/` | 3 | ~3,903 |
+| `src/mind_mem/mcp/` | 3 | ~3,960 |
 | `src/mind_mem/mcp/infra/` | 8 | ~6,696 |
-| `src/mind_mem/mcp/tools/` | 20 | ~46,458 |
+| `src/mind_mem/mcp/tools/` | 22 | ~48,867 |
 | `src/mind_mem/skill_opt/` | 11 | ~13,591 |
 | `src/mind_mem/storage/` | 2 | ~4,193 |
 | `templates/` | 19 | ~1,041 |
-| `tests/` | 252 | ~504,110 |
+| `tests/` | 254 | ~508,759 |
 | `tests/integration/` | 2 | ~1,575 |
 | `train/` | 10 | ~21,806 |
 | `web/` | 5 | ~927 |
@@ -100,7 +100,7 @@
 - `.python-version` (~2 tok, tiny) — 3.12
 - `README.md` (~23549 tok, huge) — Shared Memory Across All Your AI Agents
 - `requirements-optional.txt` (~768 tok, large) — # mind-mem optional ML stack — pinned with SHA256 integrity hashes for
-- `ROADMAP.md` (~23907 tok, huge) — mind-mem Roadmap
+- `ROADMAP.md` (~24691 tok, huge) — mind-mem Roadmap
 - `SECURITY_AUDIT_2026-04.md` (~2403 tok, huge) — Security Audit — mind-mem v3.1.9 (April 2026)
 - `SECURITY.md` (~1752 tok, huge) — Security Policy
 - `setup.py` (~397 tok, medium) — Conditional setup hook for the optional Cython accelerator.
@@ -212,7 +212,7 @@
 - `review-database-v3.2.0.md` (~3171 tok, huge) — Database Review — PostgresBlockStore v3.2.0
 - `review-docs-v3.2.0.md` (~1957 tok, huge) — Documentation Review — mind-mem v3.2.0
 - `review-tests-v3.2.0.md` (~1300 tok, large) — Test Review — mind-mem v3.2.0
-- `roadmap.md` (~11004 tok, huge) — Roadmap
+- `roadmap.md` (~11068 tok, huge) — Roadmap
 - `scoring.md` (~517 tok, large) — Scoring System
 - `SECURITY_AUDIT_SELF_2026_04.md` (~2257 tok, huge) — mind-mem v3.2.0 — Self-Audit Plan (Post-Release Deliverable)
 - `security-audit-sow.md` (~3336 tok, huge) — mind-mem — External Security Audit Statement of Work (SoW)
@@ -448,7 +448,7 @@
 - `hook_installer.py` (~9442 tok, huge) — # Copyright 2026 STARGA, Inc.
 - `http_transport.py` (~5592 tok, huge) — HTTP transport adapter for mind-mem (v3.9.0 candidate).
 - `hybrid_recall.py` (~8896 tok, huge) — mind-mem Hybrid Recall -- BM25 + Vector + RRF fusion.
-- `inbox.py` (~3552 tok, huge) — Inbox folder ingestion — `mm inbox-watch` (v3.9.0 candidate).
+- `inbox.py` (~3595 tok, huge) — Inbox folder ingestion — `mm inbox-watch` (v3.9.0 candidate).
 - `ingestion_pipeline.py` (~1752 tok, huge) — # Copyright 2026 STARGA, Inc.
 - `__init__.py` (~694 tok, large) — # Mind Mem — Memory + Immune System for AI agents
 - `init_workspace.py` (~2131 tok, huge) — mind-mem workspace initializer. Zero external deps.
@@ -477,7 +477,7 @@
 
 - `__init__.py` (~215 tok, medium) — v3.2.0 §1.2 decomposition namespace — subpackage for MCP server modules.
 - `resources.py` (~1342 tok, large) — MCP ``@mcp.resource`` declarations.
-- `server.py` (~2346 tok, huge) — FastMCP instance + ``main()`` entry point for the Mind-Mem MCP server.
+- `server.py` (~2403 tok, huge) — FastMCP instance + ``main()`` entry point for the Mind-Mem MCP server.
 ### `src/mind_mem/`
 
 - `mcp_server.py` (~1780 tok, huge) — Mind-Mem MCP Server — public facade (v3.2.0 §1.2 PR-final shim).
@@ -500,9 +500,11 @@
 - `mic_map.py` (~2436 tok, huge) — MIC/MAP serialization MCP tools — wraps ``mind_mem.mic_map``.
 - `model.py` (~2586 tok, huge) — Model audit / signing MCP tools — wraps ``mind_mem.model_audit``,
 - `ontology.py` (~969 tok, large) — Ontology MCP tools — ``ontology_load`` + ``ontology_validate``.
+- `pipeline.py` (~916 tok, large) — MCP wrapping for pipeline-hash inspection + dirty-block re-extraction.
 - `public.py` (~4515 tok, huge) — # mypy: disable-error-code="no-any-return"
 - `recall.py` (~4947 tok, huge) — Recall surface — the retrieval core of the MCP API.
 - `signal.py` (~926 tok, large) — Interaction-signal MCP tools — ``observe_signal`` + ``signal_stats``.
+- `walkthrough_persona.py` (~1493 tok, large) — MCP wrapping for v3.9 walkthrough + persona projection.
 ### `src/mind_mem/`
 
 - `memory_mesh.py` (~1903 tok, huge) — # Copyright 2026 STARGA, Inc.
@@ -527,7 +529,7 @@
 - `online_trainer.py` (~2751 tok, huge) — # Copyright 2026 STARGA, Inc.
 - `ontology.py` (~2843 tok, huge) — # Copyright 2026 STARGA, Inc.
 - `personas.py` (~1259 tok, large) — Persona-aware recall projection (v3.9.0 candidate).
-- `pipeline_hash.py` (~2117 tok, huge) — Hash-of-code pipeline invalidation (v3.9.0 candidate).
+- `pipeline_hash.py` (~3129 tok, huge) — Hash-of-code pipeline invalidation (v3.9.0 candidate).
 - `prefix_cache.py` (~3043 tok, huge) — # Copyright 2026 STARGA, Inc.
 - `preimage.py` (~1102 tok, large) — # Copyright 2026 STARGA, Inc.
 - `project_profile.py` (~1681 tok, huge) — # Copyright 2026 STARGA, Inc.
@@ -756,11 +758,13 @@
 - `test_maintenance_migrate.py` (~710 tok, large) — v3.2.0 §2.2 — tests for maintenance/ subdivision migration."""
 - `test_mcp_arch_mind_tools.py` (~2312 tok, huge) — Tests for the arch-mind MCP tool wrapper.
 - `test_mcp_integration.py` (~5301 tok, huge) — MCP transport and auth integration tests (#474).
+- `test_mcp_pipeline.py` (~1405 tok, large) — Tests for the v3.9.0 pipeline-hash MCP tools."""
 - `test_mcp_server.py` (~5169 tok, huge) — Tests for mcp_server.py — tests the MCP server resources and tool logic.
 - `test_mcp_tools_model.py` (~2249 tok, huge) — Tests for ``mind_mem.mcp.tools.model`` — MCP wrappers for audit / sign / verify."""
 - `test_mcp_tools.py` (~277 tok, medium) — Tests for MCP server tool definitions."""
 - `test_mcp_tool_surface_v3_2.py` (~2002 tok, huge) — v3.2.0 — consolidated MCP public dispatcher tests."""
 - `test_mcp_v140.py` (~5502 tok, huge) — Tests for MCP v1.4.0 features — issues #29, #31, #35, #36.
+- `test_mcp_walkthrough_persona.py` (~1942 tok, huge) — Tests for the v3.9.0 MCP walkthrough + persona wrapper tools."""
 - `test_memory_evolution.py` (~340 tok, medium) — Tests for memory evolution tracking."""
 - `test_memory_practical_e2e.py` (~2389 tok, huge) — # Copyright 2026 STARGA, Inc.
 - `test_memory_tiers.py` (~3479 tok, huge) — # Copyright 2026 STARGA, Inc.
@@ -790,7 +794,7 @@
 - `test_oidc_auth.py` (~2970 tok, huge) — Tests for OIDCProvider / OIDCConfig in src/mind_mem/api/auth.py."""
 - `test_ontology.py` (~2306 tok, huge) — # Copyright 2026 STARGA, Inc.
 - `test_personas.py` (~1336 tok, large) — Tests for the v3.9 persona-aware recall projection."""
-- `test_pipeline_hash.py` (~2007 tok, huge) — Tests for v3.9 hash-of-code pipeline invalidation."""
+- `test_pipeline_hash.py` (~3309 tok, huge) — Tests for v3.9 hash-of-code pipeline invalidation."""
 - `test_postgres_block_store.py` (~5149 tok, huge) — v3.2.0 §1.4 PR-5 — PostgresBlockStore integration tests.
 - `test_postgres_replica_routing.py` (~1777 tok, huge) — v3.2.0 — tests for read-replica routing in ReplicatedPostgresBlockStore."""
 - `test_prefetch_context.py` (~1487 tok, large) — Tests for prefetch_context() in recall.py."""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,64 @@
 
 All notable changes to mind-mem are documented in this file.
 
-## Unreleased — v3.9.0 candidates
+## v3.9.0 — MCP wrapping for v3.9 walkthrough/persona + hash-of-code loop closure
 
-**Theme: HTTP transport + replicated postgres routing.**
+**Folded into the v3.9.0 release.** v3.9.0 is the first tagged release
+in the v3.9 line; the MCP wrapping that was originally drafted as a
+v3.9.1 follow-up ships in the same release as the underlying HTTP/
+daemon/inbox/hash/personas/walkthrough modules, since v3.8.14 → v3.9.0
+is the first version bump.
+
+### Added
+- **Two new MCP tools** for `walkthrough` + `personas` (v3.9 modules
+  that previously only surfaced through the HTTP REST adapter):
+  - `compile_truth_walkthrough(topic, limit, active_only)` — returns
+    a dependency-ordered learning sequence (foundation → context →
+    current). Wraps `walkthrough.compile_walkthrough`.
+  - `recall_with_persona(query, persona, limit, active_only)` —
+    additive recall variant; reuses the existing recall pipeline
+    and projects results through `personas.apply_persona`. Three
+    personas: `brief`, `detailed`, `technical`. Kept separate from
+    the long-stable `recall` so the schema is not broken — clients
+    that want persona projection opt in by name.
+- **Two new MCP tools** for hash-of-code (v3.9 inspection primitive):
+  - `pipeline_status()` — current pipeline hash + dirty-block summary
+    (read-only).
+  - `reindex_dirty(limit, dry_run)` — re-stamp blocks whose stored
+    `TransformHash` is stale, supporting staged operator rollouts.
+- **`stamp_transform_hash(workspace, block)`** helper in
+  `pipeline_hash.py` — pure-function copy of *block* with
+  `TransformHash` set to the current pipeline hash. Used by the
+  inbox ingestion path so every newly-ingested block carries a
+  verifiable hash.
+- **`reextract_dirty_blocks(workspace, *, limit, dry_run)`** —
+  bulk re-stamp through the storage factory's `write_block`. Block
+  *content* is not re-extracted (that requires invoking the LLM
+  extractor and is left to a future revision); only the hash is
+  refreshed.
+
+### Changed
+- `inbox.ingest_text_file` and `_ingest_pdf` now wrap the block dict
+  in `stamp_transform_hash` before `write_block`, closing the v3.9
+  hash-of-code loop on the write side. Existing callers who built
+  blocks directly are unaffected (the helper is opt-in at the call
+  site, not enforced via the BlockStore interface).
+
+### Tests
+- 28 new MCP tool tests (`test_mcp_walkthrough_persona.py`,
+  `test_mcp_pipeline.py`).
+- 12 new helper tests in `test_pipeline_hash.py` (stamp + reextract).
+
+### Out of scope (deferred to v3.10)
+- Per-byte source lineage (`source_span` on every block, audit-chain
+  preimage extension). Requires the audit-chain refactor to take a
+  lineage-aware preimage; out of scope here to keep this PR focused
+  on the MCP surface + hash-of-code closure.
+- Re-extraction (vs. re-stamping) of dirty blocks via the LLM
+  extractor. v3.9.0 ships re-stamp; full content re-extract through
+  the dream cycle is the v3.10 work item.
+
+## v3.9.0 — HTTP transport + replicated postgres routing
 
 ### Added
 - **HTTP transport adapter** (`src/mind_mem/http_transport.py`).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1467,3 +1467,43 @@ mind-mem is designed as a governed-memory substrate for autonomous agents operat
 - [ ] **Cross-domain recall adapter** — given a novel environment, surface the most similar `[TRAJECTORY]` / `[SKILL]` blocks from unrelated environments by feature-embedding similarity rather than exact environment-id match
 - [ ] **`[VISUAL]` block type** — grid-state / image-state embeddings for perception-grounded memory; enables "I've seen this state before" recall across environments
 - [ ] **Evidence-chain submission format** — tamper-evident export of an agent's full decision history per episode, ready for third-party scorecard verification
+
+---
+
+## TRIZ-Driven Direction
+
+Auditable criterion for every roadmap addition. Lifted from the same TRIZ pattern in `mind/docs/roadmap.md` and `naestro/ROADMAP.md`, tuned to the persistent-memory domain.
+
+### Ideal Final Result (IFR)
+
+Persistent memory that improves agent decision quality monotonically over use, never drifts from currently-declared intent, with full provenance from query result back to the source byte that justified it, at zero recall-latency overhead vs raw vector search, and survives substrate / model / format migrations without re-ingestion.
+
+### Five Laws of System Evolution — Applied
+
+| Law | mind-mem application | Status |
+|---|---|---|
+| Uneven development | Recall surfaces evolve faster than provenance, contradiction-handling, and consolidation. Invest in audit + governance, not more recall modes. | Active investment shift toward provenance + governance |
+| Mono → bi → poly | Single-store BM25 → BM25+vector hybrid → poly-substrate (BM25 + vector + graph + governance kernel). Next: cross-machine networked mesh. | At bi → poly transition |
+| Increasing controllability | Hardcoded retrieval logic → policy-driven scoring → drift-detected policy update (v3.10). Compile-of-code-aware invalidation (v3.9) is this law's projection. | Active in v3.9 / v3.10 |
+| Micro-level transition | Coarse content blocks → smart-chunked sub-blocks → per-byte lineage. Permitted at recall and audit; forbidden at write-path (would break atomicity). | Active at correct layer only |
+| Rhythm coordination | BM25 + vector + governance kernel synchronized via RRF + atomic conjunction. Next: cross-mesh evidence federation. | In v4.0 spec |
+
+### Separation Principles for Memory Conflicts
+
+When two memory blocks contradict, when current intent conflicts with prior declared intent (intent-era drift), or when recall and write paths conflict, default to separation before retirement:
+
+- **Time** — policy A within a session, policy B across sessions; intent-era boundaries surfaced explicitly
+- **Space** — consistency rule X for compiled-truth blocks, rule Y for working-memory blocks
+- **Condition** — atomic conjunction in governance gate, RRF fusion in recall
+- **Scale** — block-level provenance for retrieval, byte-level provenance for audit
+
+v3.9 hash-of-code invalidation + v3.10 governance drift detection are the operational home for this discipline.
+
+### Anti-Patterns Made Explicit
+
+- No new block types without contradiction-handling story — every type must specify how it conflicts with existing types and how that conflict is resolved
+- No silent retrieval mode changes that affect provenance — all changes traceable to a versioned policy
+- No "more substrates = better" decisions without measured improvement on adversarial-memory + Jepsen-style stress tests
+- No retirement of an invariant before separation strategies have been exhausted (matches 512-mind Phase B addendum discipline)
+
+Acceptance gate: every new feature cites IFR component strengthened, law of evolution followed or forbidden, separation strategy for likely contradictions, and anti-pattern avoided.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -458,8 +458,8 @@ JSON-in-repo convention don't fit. Two ideas do.
 > `tests/test_walkthrough.py` (all passing). Wired into the v3.9 HTTP
 > transport as `POST /walkthrough`. The `compile_walkthrough()` Python
 > entry is also callable directly; MCP-tool wrapping (renamed
-> `compile_truth_walkthrough` per the original spec) is the v3.10
-> follow-up.
+> `compile_truth_walkthrough` per the original spec) ships in v3.9.0
+> alongside the underlying module.
 
 Today `recall` and `hybrid_search` return blocks ranked by relevance. For
 "explain the state of project X" queries, an agent gets a flat result list and
@@ -646,13 +646,15 @@ change to existing block format (new fields, old blocks get
 `transform_hash=null` and are treated as always-dirty until first
 re-extract).
 
-## v3.10.0 candidates — v3.9 follow-ups
+## v3.9.0 (shipped) + v3.10.0 candidates — v3.9 follow-ups
 
-> **Drafted (2026-05-03)** as the v3.10 release-train items. All
-> three are direct continuations of the v3.9 themes that landed on
-> `feat/v3.9-http-transport`. Together they finish the
-> "set-and-forget memory engine" story so v4.0 can focus purely on
-> networked-mesh / parallelism.
+> **Drafted (2026-05-03), folded into v3.9.0 (2026-05-04).** The
+> MCP-wrapping piece (item 3) was additive and shipped inside the
+> same v3.9.0 release as the underlying primitives, since v3.8.14 →
+> v3.9.0 was the first version bump. The lineage + extractor work
+> (items 1 & 2) involves audit-chain preimage changes and ships as
+> **v3.10**. Together they finish the "set-and-forget memory engine"
+> story so v4.0 can focus purely on networked-mesh / parallelism.
 
 ### 1. Per-byte source lineage (cocoindex theme 2)
 
@@ -687,10 +689,10 @@ v3.9 ships only the inspection primitive. v3.10 closes the loop:
 Estimated effort: 1 day (the wiring is mechanical; the primitive
 is already proven).
 
-### 3. compile_truth_walkthrough MCP wrapping + persona-aware MCP recall
+### 3. compile_truth_walkthrough MCP wrapping + persona-aware MCP recall (shipped in v3.9.0)
 
 v3.9 wires the walkthrough and persona projection into the HTTP
-transport. v3.10 wires them into MCP so AI clients (Claude Code,
+transport. v3.9.0 also wires them into MCP so AI clients (Claude Code,
 Codex, Gemini, etc.) can call them without going through HTTP:
 
 - `compile_truth_walkthrough(topic, depth=auto)` — MCP tool wrapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mind-mem"
-version = "3.8.14"
+version = "3.9.0"
 description = "Drop-in memory for Claude Code, OpenClaw, and any MCP-compatible agent."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/mind_mem/__init__.py
+++ b/src/mind_mem/__init__.py
@@ -43,7 +43,7 @@ from .protection import (
 )
 from .storage import get_block_store
 
-__version__ = "3.8.14"
+__version__ = "3.9.0"
 
 # Best-effort import-time integrity check. Fails open unless
 # MIND_MEM_INTEGRITY=strict, so editable installs and source checkouts

--- a/src/mind_mem/inbox.py
+++ b/src/mind_mem/inbox.py
@@ -147,10 +147,11 @@ def ingest_text_file(workspace: str, file_path: str) -> str:
     # Lazy import — storage factory is heavy. Keeping it out of module
     # import time means tests that exercise the routing table don't
     # need a workspace at all.
+    from .pipeline_hash import stamp_transform_hash
     from .storage import get_block_store
 
     store = get_block_store(workspace)
-    written_id = store.write_block(block)
+    written_id = store.write_block(stamp_transform_hash(workspace, block))
     _log.info("inbox_text_ingested", extra={"block_id": written_id, "source": file_path})
     return written_id
 
@@ -200,10 +201,11 @@ def _ingest_pdf(workspace: str, file_path: str) -> str:
         "Status": "active",
     }
 
+    from .pipeline_hash import stamp_transform_hash
     from .storage import get_block_store
 
     store = get_block_store(workspace)
-    return store.write_block(block)
+    return store.write_block(stamp_transform_hash(workspace, block))
 
 
 _HANDLERS: dict[str, Callable[[str, str], str]] = {

--- a/src/mind_mem/mcp/server.py
+++ b/src/mind_mem/mcp/server.py
@@ -78,10 +78,16 @@ from mind_mem.mcp.tools import (
     ontology as _tools_ontology,
 )
 from mind_mem.mcp.tools import (
+    pipeline as _tools_pipeline,
+)
+from mind_mem.mcp.tools import (
     recall as _tools_recall,
 )
 from mind_mem.mcp.tools import (
     signal as _tools_signal,
+)
+from mind_mem.mcp.tools import (
+    walkthrough_persona as _tools_walkthrough_persona,
 )
 from mind_mem.observability import get_logger
 
@@ -118,6 +124,8 @@ _tools_kernels.register(mcp)
 _tools_calibration.register(mcp)
 _tools_model.register(mcp)
 _tools_mic_map.register(mcp)
+_tools_walkthrough_persona.register(mcp)
+_tools_pipeline.register(mcp)
 
 # v3.2.0 — additive consolidated dispatchers (recall, staged_change,
 # memory_verify, graph, core, kernels, compiled_truth). Registered

--- a/src/mind_mem/mcp/tools/pipeline.py
+++ b/src/mind_mem/mcp/tools/pipeline.py
@@ -1,0 +1,122 @@
+"""MCP wrapping for pipeline-hash inspection + dirty-block re-extraction.
+
+v3.9.0 follow-up to the v3.9 ``pipeline_hash.py`` module. v3.9
+shipped the inspection primitive (which blocks were extracted by an
+older pipeline) and the ``mm pipeline-status`` CLI; this surfaces
+both inspection and the new write-side helper through MCP so AI
+clients can trigger targeted re-stamping without dropping to the
+shell.
+
+Two new tools:
+
+* :func:`pipeline_status` — read-only summary: current hash, dirty-
+  block count, inputs that produced the hash. Equivalent of the CLI
+  but JSON-shaped for tool-call use.
+
+* :func:`reindex_dirty` — write-side trigger that re-stamps blocks
+  whose ``TransformHash`` is stale. Supports ``dry_run`` and
+  ``limit`` for safe operator workflows.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..infra.observability import mcp_tool_observe
+from ..infra.workspace import _check_workspace, _workspace
+from ._helpers import get_logger
+
+_log = get_logger("mcp_server")
+
+
+__all__ = [
+    "pipeline_status",
+    "reindex_dirty",
+    "register",
+]
+
+
+@mcp_tool_observe
+def pipeline_status() -> str:
+    """Return current pipeline hash + dirty-block summary.
+
+    The pipeline hash is a deterministic SHA-256 over the package
+    version, extractor backend, model id, on-disk extractor source,
+    and prompt template. Blocks whose stored ``TransformHash`` is
+    different from the current hash are flagged as ``dirty`` and
+    can be refreshed via :func:`reindex_dirty`.
+
+    Read-only; no writes occur.
+    """
+    ws = _workspace()
+    ws_err = _check_workspace(ws)
+    if ws_err:
+        return ws_err
+
+    from mind_mem.pipeline_hash import current_pipeline_hash, pipeline_dirty_blocks
+
+    digest, inputs = current_pipeline_hash(ws, return_inputs=True)
+    dirty = pipeline_dirty_blocks(ws)
+    return json.dumps(
+        {
+            "current_hash": digest,
+            "inputs": inputs.as_dict(),
+            "dirty_count": len(dirty),
+            "dirty_ids": dirty[:25],  # head only — full list via reindex_dirty(dry_run=true)
+            "truncated": len(dirty) > 25,
+        },
+        indent=2,
+        default=str,
+    )
+
+
+@mcp_tool_observe
+def reindex_dirty(
+    limit: int = 0,
+    dry_run: bool = False,
+) -> str:
+    """Re-stamp blocks whose pipeline hash is stale.
+
+    v3.9.0 replaces v3.9's read-only inspection with a targeted
+    write: only blocks flagged as dirty by :func:`pipeline_status`
+    are touched, and only their ``TransformHash`` field is
+    refreshed (block content is *not* re-extracted — that requires
+    invoking the LLM extractor and is left to a future revision).
+
+    Args:
+        limit: Maximum number of blocks to touch. ``0`` (default)
+            means "all dirty blocks". Caps allow safe staged
+            rollouts.
+        dry_run: When True, report which blocks *would* be touched
+            without writing.
+
+    Returns:
+        ``{processed, skipped, dry_run, ids}`` summary.
+    """
+    if limit < 0:
+        return json.dumps({"error": "limit must be >= 0"})
+
+    ws = _workspace()
+    ws_err = _check_workspace(ws)
+    if ws_err:
+        return ws_err
+
+    from mind_mem.pipeline_hash import reextract_dirty_blocks
+
+    try:
+        result = reextract_dirty_blocks(
+            ws,
+            limit=limit if limit > 0 else None,
+            dry_run=bool(dry_run),
+        )
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+
+    return json.dumps(result, indent=2, default=str)
+
+
+def register(mcp: Any) -> None:
+    """Wire pipeline-hash tools onto *mcp*."""
+    mcp.tool(pipeline_status)
+    mcp.tool(reindex_dirty)

--- a/src/mind_mem/mcp/tools/walkthrough_persona.py
+++ b/src/mind_mem/mcp/tools/walkthrough_persona.py
@@ -1,0 +1,193 @@
+"""MCP wrapping for v3.9 walkthrough + persona projection.
+
+v3.9.0 follow-up to the v3.9 ``walkthrough.py`` + ``personas.py``
+modules. v3.9 wired both into the HTTP REST adapter; this surfaces
+them through the MCP server so MCP-native clients (Claude Code,
+Codex CLI, Gemini CLI, Cursor, Windsurf, Zed) can call them
+without going through HTTP.
+
+Two new tools:
+
+* :func:`compile_truth_walkthrough` — wraps
+  :func:`mind_mem.walkthrough.compile_walkthrough`. Returns a
+  dependency-ordered learning sequence
+  (``foundation`` → ``context`` → ``current``).
+
+* :func:`recall_with_persona` — additive recall variant that runs
+  ``recall(query, limit, active_only)`` and then applies
+  :func:`mind_mem.personas.apply_persona` to the result list.
+  Kept separate from the existing ``recall`` so the long-stable
+  envelope schema is not broken — clients that want persona
+  projection opt in by name.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..infra.observability import mcp_tool_observe
+from ..infra.workspace import _check_workspace, _workspace
+from ._helpers import get_logger
+
+_log = get_logger("mcp_server")
+
+
+__all__ = [
+    "compile_truth_walkthrough",
+    "recall_with_persona",
+    "register",
+]
+
+
+_DEFAULT_LIMIT = 25
+_MAX_LIMIT = 100
+_MAX_TOPIC_LEN = 4096
+
+
+@mcp_tool_observe
+def compile_truth_walkthrough(
+    topic: str,
+    limit: int = _DEFAULT_LIMIT,
+    active_only: bool = False,
+) -> str:
+    """Return *topic* memories in dependency order (foundations → current).
+
+    Re-orders the recall result for *topic* into a learning sequence
+    so agents and humans can read step 1, step 2, ... instead of a
+    flat ranked list. Step roles:
+
+    * ``foundation`` — first ~30%
+    * ``context``    — middle ~40%
+    * ``current``    — last ~30%
+
+    Algorithm: chronological backbone from each block's id
+    (YYYYMMDD prefix) reinforced by the workspace co-retrieval
+    graph. Topo-sort with Kahn's algorithm; cycles broken
+    deterministically. See :mod:`mind_mem.walkthrough`.
+
+    Args:
+        topic: Search query.
+        limit: Maximum candidates to consider (1..100).
+        active_only: Only emit blocks with active status.
+
+    Returns:
+        JSON envelope with ``steps`` (list of
+        ``{step, block_id, role, score, subject}`` dicts) and
+        ``count``. Empty steps list when *topic* yields no matches.
+    """
+    if not isinstance(topic, str) or not topic.strip():
+        return json.dumps({"error": "topic must be a non-empty string"})
+    if len(topic) > _MAX_TOPIC_LEN:
+        return json.dumps({"error": f"topic must be ≤{_MAX_TOPIC_LEN} characters"})
+    if not 1 <= limit <= _MAX_LIMIT:
+        return json.dumps({"error": f"limit must be in [1, {_MAX_LIMIT}]"})
+
+    ws = _workspace()
+    ws_err = _check_workspace(ws)
+    if ws_err:
+        return ws_err
+
+    from mind_mem.walkthrough import compile_walkthrough
+
+    try:
+        steps = compile_walkthrough(
+            workspace=ws,
+            topic=topic,
+            limit=int(limit),
+            active_only=bool(active_only),
+        )
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+
+    return json.dumps(
+        {
+            "topic": topic,
+            "count": len(steps),
+            "steps": steps,
+        },
+        indent=2,
+        default=str,
+    )
+
+
+@mcp_tool_observe
+def recall_with_persona(
+    query: str,
+    persona: str = "detailed",
+    limit: int = 10,
+    active_only: bool = False,
+) -> str:
+    """Recall memories and project the result list through *persona*.
+
+    Three personas:
+
+    * ``brief``     — ``{id, score, subject}`` only; fits routing
+                      layers, Slack snippets, status panels.
+    * ``detailed``  — full block (matches the existing ``recall``
+                      default).
+    * ``technical`` — full block plus promoted governance fields
+                      (``axis_scores``, ``governance_state``,
+                      ``provenance_hash``, ``source_span``,
+                      ``transform_hash``); fits audit consumers.
+
+    See :mod:`mind_mem.personas` for the projection rules.
+
+    Args:
+        query: Search query.
+        persona: One of ``brief``, ``detailed``, ``technical``.
+        limit: Result cap (1..500).
+        active_only: Only emit blocks with active status.
+
+    Returns:
+        JSON envelope ``{persona, query, count, results}``.
+    """
+    if not isinstance(query, str) or not query.strip():
+        return json.dumps({"error": "query must be a non-empty string"})
+    if not 1 <= limit <= 500:
+        return json.dumps({"error": "limit must be in [1, 500]"})
+
+    from mind_mem.personas import PERSONAS, PersonaError, apply_persona
+
+    if persona not in PERSONAS:
+        return json.dumps({"error": f"unknown persona {persona!r}; must be one of {list(PERSONAS)}"})
+
+    ws = _workspace()
+    ws_err = _check_workspace(ws)
+    if ws_err:
+        return ws_err
+
+    # Reuse the recall MCP impl so cache, axes, observability all flow through.
+    from .recall import _recall_impl
+
+    raw = _recall_impl(query, limit=int(limit), active_only=bool(active_only))
+    try:
+        envelope = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw  # _recall_impl already returned an error JSON
+
+    if not isinstance(envelope, dict) or "results" not in envelope:
+        return raw
+
+    results: list[dict[str, Any]] = list(envelope.get("results", []))
+    try:
+        projected = apply_persona(results, persona)
+    except PersonaError as exc:
+        return json.dumps({"error": str(exc)})
+
+    return json.dumps(
+        {
+            "persona": persona,
+            "query": query,
+            "count": len(projected),
+            "results": projected,
+        },
+        indent=2,
+        default=str,
+    )
+
+
+def register(mcp: Any) -> None:
+    """Wire walkthrough + persona tools onto *mcp*."""
+    mcp.tool(compile_truth_walkthrough)
+    mcp.tool(recall_with_persona)

--- a/src/mind_mem/pipeline_hash.py
+++ b/src/mind_mem/pipeline_hash.py
@@ -45,6 +45,8 @@ __all__ = [
     "PipelineHashInputs",
     "compute_pipeline_hash",
     "pipeline_dirty_blocks",
+    "stamp_transform_hash",
+    "reextract_dirty_blocks",
 ]
 
 _log = logging.getLogger("mind_mem.pipeline_hash")
@@ -187,6 +189,115 @@ def current_pipeline_hash(workspace: str, *, return_inputs: bool = False) -> str
     if return_inputs:
         return (digest, inputs)
     return digest
+
+
+# ---------------------------------------------------------------------------
+# v3.10: write-side helpers — auto-stamp + targeted re-extract
+# ---------------------------------------------------------------------------
+
+
+def stamp_transform_hash(workspace: str, block: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *block* with ``TransformHash`` set to the current pipeline hash.
+
+    Use this at write time so any block produced by the current
+    extractor pipeline carries a verifiable hash. The block is *not*
+    mutated; the returned dict is a shallow copy so callers can pass
+    immutable input.
+
+    If the input already carries a ``TransformHash`` (e.g. block was
+    re-stamped earlier in the request) it is overwritten — the field
+    always reflects the *currently configured* pipeline.
+
+    Markdown's block-parser only retains fields that start with a
+    capital letter, so we always write ``TransformHash`` (CapitalCase).
+    Postgres / sqlite-vec backends accept either form.
+    """
+    if not isinstance(block, dict):
+        raise TypeError("block must be a dict")
+    digest = current_pipeline_hash(workspace)
+    if not isinstance(digest, str):
+        # current_pipeline_hash without return_inputs returns str; this
+        # narrows the type at runtime so bandit/mypy see the contract
+        # without relying on `assert` (stripped in -O bytecode).
+        raise TypeError(f"pipeline hash must be str, got {type(digest).__name__}")
+    out = dict(block)
+    out["TransformHash"] = digest
+    # Drop the lowercase form to avoid two-of-truth on round-trip.
+    out.pop("transform_hash", None)
+    return out
+
+
+def reextract_dirty_blocks(
+    workspace: str,
+    *,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Re-stamp blocks whose ``TransformHash`` is stale.
+
+    v3.10: targeted alternative to a full ``reindex``. The function
+    finds dirty blocks via :func:`pipeline_dirty_blocks` and rewrites
+    each one through the storage factory's ``write_block``. Block
+    *content* is not re-extracted — that requires invoking the LLM
+    extractor and is intentionally left to a future revision; this
+    helper only refreshes the hash so consumers can see "this block
+    has been verified against the new pipeline".
+
+    Args:
+        workspace: Workspace root.
+        limit: Maximum number of blocks to touch; ``None`` for all.
+        dry_run: When True, return the list of blocks that would be
+            re-stamped without writing.
+
+    Returns:
+        ``{processed, skipped, dry_run, ids}`` summary dict.
+    """
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be >= 1 when set")
+
+    dirty_ids = pipeline_dirty_blocks(workspace)
+    if limit is not None:
+        dirty_ids = dirty_ids[:limit]
+
+    if dry_run:
+        return {
+            "processed": 0,
+            "skipped": 0,
+            "dry_run": True,
+            "ids": dirty_ids,
+        }
+
+    from .storage import get_block_store
+
+    try:
+        store = get_block_store(workspace)
+    except Exception as exc:
+        _log.warning("dirty_reextract_store_failed", extra={"error": str(exc)})
+        return {"processed": 0, "skipped": len(dirty_ids), "dry_run": False, "ids": []}
+
+    processed: list[str] = []
+    skipped: list[str] = []
+    for bid in dirty_ids:
+        try:
+            block = store.get_by_id(bid) if hasattr(store, "get_by_id") else None
+            if block is None:
+                skipped.append(bid)
+                continue
+            store.write_block(stamp_transform_hash(workspace, block))
+            processed.append(bid)
+        except Exception as exc:
+            _log.warning(
+                "dirty_reextract_failed",
+                extra={"block_id": bid, "error": str(exc)},
+            )
+            skipped.append(bid)
+
+    return {
+        "processed": len(processed),
+        "skipped": len(skipped),
+        "dry_run": False,
+        "ids": processed,
+    }
 
 
 def pipeline_dirty_blocks(workspace: str) -> list[str]:

--- a/tests/test_mcp_pipeline.py
+++ b/tests/test_mcp_pipeline.py
@@ -1,0 +1,160 @@
+"""Tests for the v3.9.0 pipeline-hash MCP tools."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mind_mem.mcp.infra.rate_limit import _rate_limiters, _rate_limiters_lock
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_rate_limiters():
+    """Clear the process-global MCP rate-limiter cache between tests."""
+    with _rate_limiters_lock:
+        _rate_limiters.clear()
+    yield
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    ws = tmp_path / "ws"
+    (ws / "decisions").mkdir(parents=True)
+    (ws / "memory").mkdir()
+    (ws / "tasks").mkdir()
+    (ws / "intelligence" / "state").mkdir(parents=True)
+    (ws / "mind-mem.json").write_text(
+        json.dumps(
+            {
+                "version": "3.10.0",
+                "workspace_path": str(ws),
+                "block_store": {"backend": "markdown"},
+            }
+        )
+    )
+    monkeypatch.setenv("MIND_MEM_WORKSPACE", str(ws))
+    return str(ws)
+
+
+def _seed_dirty_block(workspace: str) -> str:
+    block_id = "D-20260503-500"
+    (Path(workspace) / "decisions" / "DECISIONS.md").write_text(f"[{block_id}]\nStatus: active\nStatement: stale block, no TransformHash\n")
+    return block_id
+
+
+# ---------------------------------------------------------------------------
+# pipeline_status
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineStatus:
+    def test_envelope_keys(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import pipeline_status
+
+        out = json.loads(pipeline_status())
+        assert {"current_hash", "inputs", "dirty_count", "dirty_ids", "truncated"} <= set(out.keys())
+        assert isinstance(out["current_hash"], str)
+        assert len(out["current_hash"]) == 64
+
+    def test_inputs_carry_pipeline_metadata(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import pipeline_status
+
+        out = json.loads(pipeline_status())
+        inputs = out["inputs"]
+        assert {
+            "package_version",
+            "backend",
+            "model",
+            "extractor_source_sha256",
+            "prompt_template_sha256",
+        } <= set(inputs.keys())
+
+    def test_dirty_count_zero_on_empty_workspace(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import pipeline_status
+
+        out = json.loads(pipeline_status())
+        assert out["dirty_count"] == 0
+        assert out["dirty_ids"] == []
+        assert out["truncated"] is False
+
+    def test_dirty_count_after_seeding(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import pipeline_status
+
+        block_id = _seed_dirty_block(workspace)
+        out = json.loads(pipeline_status())
+        assert out["dirty_count"] >= 1
+        assert block_id in out["dirty_ids"]
+
+
+# ---------------------------------------------------------------------------
+# reindex_dirty
+# ---------------------------------------------------------------------------
+
+
+class TestReindexDirty:
+    def test_dry_run_lists_without_writing(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import reindex_dirty
+
+        block_id = _seed_dirty_block(workspace)
+        out = json.loads(reindex_dirty(dry_run=True))
+        assert out["dry_run"] is True
+        assert out["processed"] == 0
+        assert block_id in out["ids"]
+        # File should still lack TransformHash.
+        text = (Path(workspace) / "decisions" / "DECISIONS.md").read_text()
+        assert "TransformHash:" not in text
+
+    def test_processes_and_stamps(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import reindex_dirty
+
+        _seed_dirty_block(workspace)
+        out = json.loads(reindex_dirty())
+        assert out["dry_run"] is False
+        assert out["processed"] == 1
+        text = (Path(workspace) / "decisions" / "DECISIONS.md").read_text()
+        assert "TransformHash:" in text
+
+    def test_after_processing_status_clean(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import pipeline_status, reindex_dirty
+
+        _seed_dirty_block(workspace)
+        json.loads(reindex_dirty())
+        status = json.loads(pipeline_status())
+        # The seeded block should no longer appear.
+        assert "D-20260503-500" not in status["dirty_ids"]
+
+    def test_negative_limit_rejected(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import reindex_dirty
+
+        out = json.loads(reindex_dirty(limit=-1))
+        assert "error" in out and "limit" in out["error"]
+
+    def test_zero_limit_means_all(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.pipeline import reindex_dirty
+
+        # Seed multiple dirty blocks.
+        (Path(workspace) / "decisions" / "DECISIONS.md").write_text(
+            "[D-20260503-600]\nStatus: active\nStatement: a\n\n"
+            "[D-20260503-601]\nStatus: active\nStatement: b\n\n"
+            "[D-20260503-602]\nStatus: active\nStatement: c\n"
+        )
+        out = json.loads(reindex_dirty(limit=0, dry_run=True))
+        assert len(out["ids"]) >= 3
+
+
+class TestRegister:
+    def test_register_wires_both(self) -> None:
+        from mind_mem.mcp.tools import pipeline as pipeline_module
+
+        registered: list[object] = []
+
+        class FakeMCP:
+            def tool(self, fn: object) -> object:
+                registered.append(fn)
+                return fn
+
+        pipeline_module.register(FakeMCP())
+        assert pipeline_module.pipeline_status in registered
+        assert pipeline_module.reindex_dirty in registered

--- a/tests/test_mcp_walkthrough_persona.py
+++ b/tests/test_mcp_walkthrough_persona.py
@@ -1,0 +1,203 @@
+"""Tests for the v3.9.0 MCP walkthrough + persona wrapper tools."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mind_mem.mcp.infra.rate_limit import _rate_limiters, _rate_limiters_lock
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_rate_limiters():
+    """Clear the process-global MCP rate-limiter cache between tests.
+
+    The limiter is keyed by client_id (``"default"`` in tests). Without
+    this reset, prior MCP tool calls in the same pytest session exhaust
+    the budget and the tool returns a rate-limit envelope instead of
+    the result envelope these tests assert on.
+    """
+    with _rate_limiters_lock:
+        _rate_limiters.clear()
+    yield
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    ws = tmp_path / "ws"
+    (ws / "decisions").mkdir(parents=True)
+    (ws / "intelligence" / "state").mkdir(parents=True)
+    (ws / "memory").mkdir()
+    (ws / "tasks").mkdir()
+    (ws / "entities").mkdir()
+    (ws / "mind-mem.json").write_text(
+        json.dumps(
+            {
+                "version": "3.10.0",
+                "workspace_path": str(ws),
+                "block_store": {"backend": "markdown"},
+            }
+        )
+    )
+
+    decisions = """[D-20260101-001]
+Date: 2026-01-01
+Status: active
+Subject: Authentication foundation chosen
+Statement: Adopt OAuth2 with PKCE for the auth subsystem rewrite.
+
+[D-20260201-001]
+Date: 2026-02-01
+Status: active
+Subject: JWT signing key rotation policy
+Statement: Authentication keys rotate every 30 days.
+
+[D-20260301-001]
+Date: 2026-03-01
+Status: active
+Subject: MFA rollout schedule
+Statement: Authentication MFA gates rolled out per cohort.
+"""
+    (ws / "decisions" / "DECISIONS.md").write_text(decisions)
+    monkeypatch.setenv("MIND_MEM_WORKSPACE", str(ws))
+    return str(ws)
+
+
+# ---------------------------------------------------------------------------
+# compile_truth_walkthrough
+# ---------------------------------------------------------------------------
+
+
+class TestCompileTruthWalkthrough:
+    def test_topic_required(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import compile_truth_walkthrough
+
+        out = json.loads(compile_truth_walkthrough(""))
+        assert "error" in out and "topic" in out["error"]
+
+    def test_topic_too_long(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import compile_truth_walkthrough
+
+        out = json.loads(compile_truth_walkthrough("x" * 5000))
+        assert "error" in out and "≤4096" in out["error"]
+
+    def test_limit_out_of_range(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import compile_truth_walkthrough
+
+        out = json.loads(compile_truth_walkthrough("auth", limit=0))
+        assert "error" in out and "limit" in out["error"]
+        out = json.loads(compile_truth_walkthrough("auth", limit=999))
+        assert "error" in out and "limit" in out["error"]
+
+    def test_returns_envelope_with_steps(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import compile_truth_walkthrough
+
+        out = json.loads(compile_truth_walkthrough("authentication"))
+        assert "topic" in out and out["topic"] == "authentication"
+        assert "count" in out
+        assert "steps" in out
+        assert isinstance(out["steps"], list)
+
+    def test_steps_have_chronological_order(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import compile_truth_walkthrough
+        from mind_mem.walkthrough import _date_key
+
+        out = json.loads(compile_truth_walkthrough("authentication"))
+        if len(out["steps"]) >= 2:
+            dates = [_date_key(s["block_id"]) for s in out["steps"]]
+            assert dates == sorted(dates)
+
+    def test_no_match_empty_steps(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import compile_truth_walkthrough
+
+        out = json.loads(compile_truth_walkthrough("nope-not-real-zzz-9999"))
+        assert out["count"] == 0
+        assert out["steps"] == []
+
+
+# ---------------------------------------------------------------------------
+# recall_with_persona
+# ---------------------------------------------------------------------------
+
+
+class TestRecallWithPersona:
+    def test_query_required(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona(""))
+        assert "error" in out and "query" in out["error"]
+
+    def test_unknown_persona_rejected(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona("auth", persona="bogus"))
+        assert "error" in out and "persona" in out["error"]
+
+    def test_limit_out_of_range(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona("auth", limit=0))
+        assert "error" in out and "limit" in out["error"]
+        out = json.loads(recall_with_persona("auth", limit=99999))
+        assert "error" in out and "limit" in out["error"]
+
+    def test_brief_persona_returns_compact_shape(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona("authentication", persona="brief"))
+        assert out["persona"] == "brief"
+        assert "results" in out
+        for r in out["results"]:
+            # brief = {id, score, subject} only
+            assert set(r.keys()) == {"id", "score", "subject"}
+
+    def test_detailed_persona_default(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona("authentication"))
+        assert out["persona"] == "detailed"
+
+    def test_technical_persona_promotes_governance(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona("authentication", persona="technical"))
+        assert out["persona"] == "technical"
+        # technical is identity + governance promotion; results may be empty
+        # for synthetic data, but the persona key still reports correctly.
+        assert "results" in out
+
+    def test_envelope_keys(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona("authentication", persona="brief"))
+        assert {"persona", "query", "count", "results"} <= set(out.keys())
+        assert out["query"] == "authentication"
+
+    def test_count_matches_results_length(self, workspace: str) -> None:
+        from mind_mem.mcp.tools.walkthrough_persona import recall_with_persona
+
+        out = json.loads(recall_with_persona("authentication", persona="brief"))
+        assert out["count"] == len(out["results"])
+
+
+# ---------------------------------------------------------------------------
+# register
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_calls_mcp_tool_for_each(self) -> None:
+        from mind_mem.mcp.tools import walkthrough_persona
+
+        registered: list[object] = []
+
+        class FakeMCP:
+            def tool(self, fn: object) -> object:
+                registered.append(fn)
+                return fn
+
+        walkthrough_persona.register(FakeMCP())
+        assert walkthrough_persona.compile_truth_walkthrough in registered
+        assert walkthrough_persona.recall_with_persona in registered

--- a/tests/test_pipeline_hash.py
+++ b/tests/test_pipeline_hash.py
@@ -13,6 +13,8 @@ from mind_mem.pipeline_hash import (
     compute_pipeline_hash,
     current_pipeline_hash,
     pipeline_dirty_blocks,
+    reextract_dirty_blocks,
+    stamp_transform_hash,
 )
 
 # ---------------------------------------------------------------------------
@@ -189,3 +191,98 @@ class TestPipelineDirtyBlocks:
         )
         dirty = pipeline_dirty_blocks(str(workspace))
         assert "D-20260503-003" in dirty
+
+
+# ---------------------------------------------------------------------------
+# v3.10: stamp_transform_hash + reextract_dirty_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestStampTransformHash:
+    def test_returns_copy_with_hash(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        block = {"_id": "D-20260503-100", "Statement": "test"}
+        stamped = stamp_transform_hash(str(workspace), block)
+        assert "TransformHash" in stamped
+        assert isinstance(stamped["TransformHash"], str)
+        assert len(stamped["TransformHash"]) == 64  # hex sha256
+
+    def test_does_not_mutate_input(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        block = {"_id": "D-20260503-101", "Statement": "test"}
+        original = dict(block)
+        stamp_transform_hash(str(workspace), block)
+        assert block == original
+
+    def test_overwrites_existing_hash(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        block = {"_id": "D-20260503-102", "TransformHash": "stale"}
+        stamped = stamp_transform_hash(str(workspace), block)
+        assert stamped["TransformHash"] != "stale"
+
+    def test_drops_lowercase_form(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        block = {"_id": "D-20260503-103", "transform_hash": "old-lower"}
+        stamped = stamp_transform_hash(str(workspace), block)
+        assert "transform_hash" not in stamped
+        assert "TransformHash" in stamped
+
+    def test_rejects_non_dict(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        with pytest.raises(TypeError, match="dict"):
+            stamp_transform_hash(str(workspace), "not a block")  # type: ignore[arg-type]
+
+    def test_hash_matches_current_pipeline(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        block = {"_id": "D-20260503-104"}
+        stamped = stamp_transform_hash(str(workspace), block)
+        assert stamped["TransformHash"] == current_pipeline_hash(str(workspace))
+
+
+class TestReextractDirtyBlocks:
+    def test_dry_run_lists_without_writing(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        (workspace / "decisions" / "DECISIONS.md").write_text("[D-20260503-200]\nStatus: active\nStatement: stale\n")
+        result = reextract_dirty_blocks(str(workspace), dry_run=True)
+        assert result["dry_run"] is True
+        assert result["processed"] == 0
+        assert "D-20260503-200" in result["ids"]
+
+    def test_processes_dirty_blocks(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        (workspace / "decisions" / "DECISIONS.md").write_text("[D-20260503-201]\nStatus: active\nStatement: stale\n")
+        result = reextract_dirty_blocks(str(workspace))
+        assert result["dry_run"] is False
+        assert result["processed"] == 1
+        # After processing, the block should now carry the current hash.
+        text = (workspace / "decisions" / "DECISIONS.md").read_text()
+        assert "TransformHash:" in text
+
+    def test_after_reextract_no_dirty(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        (workspace / "decisions" / "DECISIONS.md").write_text("[D-20260503-202]\nStatus: active\nStatement: stale\n")
+        reextract_dirty_blocks(str(workspace))
+        # Re-check: should now be clean.
+        dirty = pipeline_dirty_blocks(str(workspace))
+        assert "D-20260503-202" not in dirty
+
+    def test_limit_caps_work(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        (workspace / "decisions" / "DECISIONS.md").write_text(
+            "[D-20260503-300]\nStatus: active\nStatement: a\n\n"
+            "[D-20260503-301]\nStatus: active\nStatement: b\n\n"
+            "[D-20260503-302]\nStatus: active\nStatement: c\n"
+        )
+        result = reextract_dirty_blocks(str(workspace), limit=2, dry_run=True)
+        assert len(result["ids"]) == 2
+
+    def test_invalid_limit_rejected(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        with pytest.raises(ValueError, match="limit"):
+            reextract_dirty_blocks(str(workspace), limit=0)
+
+    def test_empty_workspace_clean(self, workspace: Path) -> None:
+        _write_config(workspace, {"version": "3.10.0", "block_store": {"backend": "markdown"}})
+        result = reextract_dirty_blocks(str(workspace))
+        assert result["processed"] == 0
+        assert result["skipped"] == 0


### PR DESCRIPTION
v3.9.0 release. Folds the originally-drafted v3.10 MCP wrapping into v3.9.0 since v3.8.14→v3.9.0 is the first version bump.

## What ships

**MCP tools (4 new):**
- `compile_truth_walkthrough(topic, limit, active_only)`
- `recall_with_persona(query, persona, limit, active_only)`
- `pipeline_status()`
- `reindex_dirty(limit, dry_run)`

**Pipeline-hash helpers:**
- `stamp_transform_hash(workspace, block)` — used by inbox ingestion
- `reextract_dirty_blocks(workspace, *, limit, dry_run)` — bulk re-stamp

**Fixes:**
- B101: `stamp_transform_hash` drops assert → raises TypeError (survives `-O`)
- Test fix: autouse `_reset_mcp_rate_limiters` fixture on new MCP test files

**Bumps:** `__version__` and `pyproject.toml` to 3.9.0

## Tests

4631 passed, 26 skipped, 0 failed. ruff + mypy + Bandit clean.
No SKIPPED checks (docker-scan workflow fix in PR #520 already on main).

## Replaces

#521 (rebase conflicts on stale v3.10 commits). This branch is a clean fork off post-#520 main.