### PR TITLE
chore(train): v3.9 retrain prep — corpus walks new mcp/tools/ + v3.9 eval probes

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -5,8 +5,8 @@
 > Re-generate with: `anatomy .`
 
 **Project:** `mind-mem`
-**Files:** 729 | **Est. tokens:** ~1,502,449
-**Generated:** 2026-05-04 02:42 UTC
+**Files:** 730 | **Est. tokens:** ~1,505,822
+**Generated:** 2026-05-04 05:02 UTC
 
 ## Token Budget Guide
 
@@ -64,7 +64,7 @@
 | `templates/` | 19 | ~1,041 |
 | `tests/` | 254 | ~508,759 |
 | `tests/integration/` | 2 | ~1,575 |
-| `train/` | 10 | ~21,806 |
+| `train/` | 11 | ~25,179 |
 | `web/` | 5 | ~927 |
 | `web/app/` | 2 | ~1,204 |
 | `web/app/console/` | 1 | ~1,169 |
@@ -888,11 +888,12 @@
 ### `train/`
 
 - `backport_sweep.py` (~1658 tok, huge) — Backport v2.9.0 audit fixes to every prior v2.x release as .post1.
-- `build_corpus.py` (~8110 tok, huge) — Harvest a training corpus for the mind-mem-4b model.
+- `build_corpus.py` (~8473 tok, huge) — Harvest a training corpus for the mind-mem-4b model.
 - `build_model_card.py` (~1876 tok, huge) — Generate the HuggingFace model-card README for mind-mem-4b v3.0.0."""
-- `eval_harness.py` (~2137 tok, huge) — Eval harness for mind-mem-4b.
+- `eval_harness.py` (~3742 tok, huge) — Eval harness for mind-mem-4b.
 - `export_gguf.py` (~1047 tok, large) — Merge the LoRA adapter into the base weights, then export to GGUF.
 - `README.md` (~577 tok, large) — mind-mem-4b training pipeline
+- `RETRAIN_v3.9.0.md` (~1405 tok, large) — mind-mem-4b — v3.9.0 retrain plan
 - `runpod_deploy.py` (~3095 tok, huge) — End-to-end RunPod driver for full-FT on Qwen3.5-4B.
 - `runpod_full_ft.py` (~1246 tok, large) — Full fine-tune of Qwen3.5-4B on RunPod (A100/H100) for mind-mem-4b.
 - `train_qlora.py` (~1195 tok, large) — QLoRA fine-tune for mind-mem-4b on the harvested corpus.

--- a/train/RETRAIN_v3.9.0.md
+++ b/train/RETRAIN_v3.9.0.md
@@ -1,0 +1,111 @@
+# mind-mem-4b — v3.9.0 retrain plan
+
+> **Status:** drafted 2026-05-04 after v3.9.0 PyPI release. Schema delta from v3.0.0-era fine-tune is large enough to warrant a full retrain rather than continued LoRA on the existing checkpoint.
+
+## Why retrain now
+
+The previous fine-tune (`star-ga/mind-mem-4b`, Q4_K_M) was trained against the v3.0.0 surface: **57 MCP tools**, no `TransformHash` field, single Markdown / sqlite-vec backends, no HTTP transport, no inbox, no daemon, no walkthrough, no personas.
+
+v3.9.0 surface (today):
+
+| Axis | v3.0.0 | v3.9.0 | Delta |
+|------|--------|--------|-------|
+| MCP tools | 57 | **81** | +24 (incl. `compile_truth_walkthrough`, `recall_with_persona`, `pipeline_status`, `reindex_dirty`, MIC/MAP, model audit/sign, audit-pinned, governance hooks, kernels, etc.) |
+| Block fields | base | base + `TransformHash` | +1 schema field |
+| Transports | MCP only | MCP + HTTP + inbox + daemon | +3 surfaces |
+| Backends | Markdown, sqlite-vec | Markdown, sqlite-vec, **replicated Postgres** | +1 routing layer |
+| Personas | none | brief / detailed / technical | +3 projection modes |
+
+**Symptom of drift if we don't retrain:** the model invents tool names that don't exist (it remembers `add_memory` from v2.x, doesn't know `compile_truth_walkthrough`), recommends `transform_hash` lowercase (Postgres-only) instead of `TransformHash` (Markdown-canonical), can't reason about HTTP/daemon transports.
+
+## Pipeline (already on disk)
+
+The training scaffolding shipped in `train/` (last touched 2026-04-18):
+
+```
+build_corpus.py → train_qlora.py → eval_harness.py → export_gguf.py → upload_to_hf.py
+```
+
+Output landing pad: `/data/checkpoints/mm-workspace/train-output/`.
+
+## Blocker — build_corpus.py is stale
+
+The current corpus harvester walks `src/mind_mem/mcp_server.py` only. As of v3.4 the tools were extracted into `src/mind_mem/mcp/tools/*.py` and registered through per-module `register()` callbacks. **Result: the existing builder sees 1 tool, not 81.** Any retrain run today would produce a corpus that teaches the model the v3.0 surface again.
+
+### Fix (15-min change)
+
+1. In `train/build_corpus.py`, replace the single-file AST walk with:
+
+   ```python
+   tools_dir = REPO / "src" / "mind_mem" / "mcp" / "tools"
+   sources = [REPO / "src" / "mind_mem" / "mcp_server.py"]
+   sources.extend(p for p in tools_dir.glob("*.py") if p.name not in ("__init__.py", "_helpers.py"))
+   for path in sources:
+       tree = ast.parse(path.read_text(encoding="utf-8"))
+       ...
+   ```
+
+2. Update the decorator detector to match `@mcp_tool_observe` (the new wrapper) in addition to `@mcp.tool` / `@tool`:
+
+   ```python
+   def _is_tool_decorator(d):
+       if isinstance(d, ast.Attribute) and d.attr == "tool": return True
+       if isinstance(d, ast.Name) and d.id in ("tool", "mcp_tool_observe"): return True
+       return False
+   ```
+
+3. Update `SYSTEM_PROMPT` count: `"57 MCP tools"` → `"81 MCP tools"`.
+
+4. Add a v3.9.0 `TransformHash` schema example to the block-grammar source.
+
+5. Bump `CHANGELOG_LIMIT` (or remove the cap) so v3.4–v3.9 entries get harvested.
+
+## Hardware + budget
+
+- **GPU:** RTX 3080 10 GB VRAM (local). QLoRA on Qwen3.5-4B fits.
+- **Wall time:** 2–4 hours for ~600 examples × 3 epochs (current corpus is ~393; +200 from new tools).
+- **Disk:** ~20 GB in `~/.cache/huggingface/hub` (already populated) + `/data/checkpoints/mm-workspace/train-output/` (currently 0 free of 250 GB).
+- **Cost:** $0 — local box.
+
+If wall-time matters, the same script runs on Runpod H200 (`benchmarks/train_mind_mem_4b.py` is the H200 full-fine-tune variant). H200 takes ~30 min, ~$3 spot.
+
+## Eval gates (already in `eval_harness.py`)
+
+Exit non-zero if any of:
+- tool-call accuracy < 95%
+- block-schema validity < 98%
+- end-to-end governance workflow < 90%
+
+For v3.9 we also want:
+- v3.9-specific tool name recall (the 24 new tools) ≥ 90%
+- `TransformHash` field cited in block-write examples ≥ 95%
+- HTTP/inbox/daemon transport mentions don't hallucinate endpoints
+
+I'll add three new probes to `eval_harness.py` to cover these — separate small commit.
+
+## Rollout
+
+1. Train → eval gate → export GGUF (Q4_K_M, ~2.7 GB).
+2. Push to HF as `star-ga/mind-mem-4b` revision `v3.9.0` (overwrite default branch only after eval green; previous v3.0 fine-tune stays accessible via `revision="v3.0.0"`).
+3. Update `Modelfile.mind-mem-4b` to point at the new GGUF.
+4. `ollama create mind-mem:4b-v3.9 -f Modelfile.mind-mem-4b-v3.9` → smoke test.
+5. Update `mind-mem.json` default `extraction.model` from `mind-mem:4b` to `mind-mem:4b-v3.9` (with a brief grace window where both aliases resolve).
+
+## Non-goals
+
+- No architecture change (still Qwen3.5-4B base, full FT).
+- No pretraining-data change.
+- No new prompt template — the SYSTEM_PROMPT only grows the tool-count field; everything else stays.
+
+## Order of operations
+
+1. Patch `build_corpus.py` (3 small edits above).
+2. Add v3.9 probes to `eval_harness.py`.
+3. Run `build_corpus.py` → diff against the v3.0 corpus to confirm the 24 new tools surface.
+4. `train_qlora.py` (overnight on the 3080, or 30 min on H200).
+5. `eval_harness.py` — gate.
+6. `export_gguf.py` → `upload_to_hf.py` → smoke test in Ollama.
+
+## What I'm not committing here
+
+The corpus-builder patch is the only pre-condition that needs a code change. Everything else is execution. **I'm not kicking off training until you confirm** — RTX 3080 is the only local GPU, and an overnight training run blocks other GPU work (NikolaChess testing, llama-server, etc.). Cheaper to defer to the next idle window or send to Runpod H200.

--- a/train/build_corpus.py
+++ b/train/build_corpus.py
@@ -42,7 +42,7 @@ OUT = Path(
 SYSTEM_PROMPT = (
     "You are mind-mem-4b, a memory-governance assistant specialised in "
     "auditable, contradiction-safe memory for coding agents. You know "
-    "the mind-mem Python package, its 57 MCP tools, block schemas, "
+    "the mind-mem Python package, its 81 MCP tools, block schemas, "
     "governance workflows, and CHANGELOG history. You respond "
     "concisely, cite exact tool names / block types, and refuse to "
     "invent APIs that do not exist in the package."
@@ -54,79 +54,125 @@ SYSTEM_PROMPT = (
 # ---------------------------------------------------------------------------
 
 
+def _is_tool_decorator(decorator: ast.expr) -> bool:
+    """Match the three decorator forms used across mcp_server + mcp/tools/.
+
+    * ``@mcp.tool``           — legacy form on mcp_server.py
+    * ``@tool``               — alias inside mcp_server.py
+    * ``@mcp_tool_observe``   — v3.4+ wrapper used by every module under
+                                 src/mind_mem/mcp/tools/*.py
+    """
+    if isinstance(decorator, ast.Attribute) and decorator.attr == "tool":
+        return True
+    if isinstance(decorator, ast.Name) and decorator.id in ("tool", "mcp_tool_observe"):
+        return True
+    return False
+
+
+def _tool_source_files() -> list[Path]:
+    """Every .py file that may register an MCP tool.
+
+    v3.4 split ``mcp_server.py`` into per-domain modules under
+    ``mcp/tools/`` registered via per-module ``register(mcp)`` callbacks.
+    Walking only the legacy ``mcp_server.py`` would have missed all 81
+    tools currently shipped — every retrain after v3.4 must walk the
+    new directory too.
+    """
+    sources: list[Path] = [REPO / "src" / "mind_mem" / "mcp_server.py"]
+    tools_dir = REPO / "src" / "mind_mem" / "mcp" / "tools"
+    if tools_dir.is_dir():
+        for path in sorted(tools_dir.glob("*.py")):
+            if path.name in ("__init__.py", "_helpers.py"):
+                continue
+            sources.append(path)
+    return sources
+
+
 def _harvest_mcp_tools() -> Iterator[dict]:
-    """Extract every @mcp.tool function + docstring from mcp_server.py.
+    """Extract every MCP tool function + docstring from mcp_server.py and mcp/tools/.
 
     Emits multiple Q/A variants per tool to drive name recall under
     different phrasings. Tool names must appear in every assistant
     response so the model learns "cite the exact tool".
     """
-    path = REPO / "src" / "mind_mem" / "mcp_server.py"
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef):
+    for path in _tool_source_files():
+        if not path.is_file():
             continue
-        if not any(
-            (isinstance(d, ast.Attribute) and d.attr == "tool") or (isinstance(d, ast.Name) and d.id == "tool") for d in node.decorator_list
-        ):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
             continue
-        doc = ast.get_docstring(node) or ""
-        if not doc.strip():
-            continue
-        summary = doc.strip().split("\n\n")[0].replace("\n", " ")
-        args = _fn_arg_repr(node)
-        tool_name = node.name
-        hint = _usage_hint(summary)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if not any(_is_tool_decorator(d) for d in node.decorator_list):
+                continue
+            doc = ast.get_docstring(node) or ""
+            if not doc.strip():
+                continue
+            summary = doc.strip().split("\n\n")[0].replace("\n", " ")
+            args = _fn_arg_repr(node)
+            tool_name = node.name
+            hint = _usage_hint(summary)
+            yield from _emit_tool_variants(tool_name, args, summary, hint, doc)
 
-        # Variant 1 — documentation lookup.
+
+def _emit_tool_variants(
+    tool_name: str,
+    args: str,
+    summary: str,
+    hint: str,
+    doc: str,
+) -> Iterator[dict]:
+    # Variant 1 — documentation lookup.
+    yield {
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"What does the mind-mem MCP tool `{tool_name}` do?"},
+            {"role": "assistant", "content": f"`{tool_name}({args})` — {summary}"},
+        ]
+    }
+    # Variant 2 — reverse lookup by intent.
+    yield {
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"Which MCP tool should I call to {hint}?"},
+            {"role": "assistant", "content": f"Call `{tool_name}`. Signature: `{tool_name}({args})`."},
+        ]
+    }
+    # Variant 3 — short direct form.
+    yield {
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"Name the mind-mem tool for: {hint}."},
+            {"role": "assistant", "content": f"`{tool_name}`."},
+        ]
+    }
+    # Variant 4 — signature question.
+    yield {
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"What is the signature of `{tool_name}`?"},
+            {"role": "assistant", "content": f"`{tool_name}({args})`"},
+        ]
+    }
+    # Variant 5 — what returns.
+    yield {
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"What does `{tool_name}` return?"},
+            {"role": "assistant", "content": (f"`{tool_name}` returns a JSON envelope. From the docstring:\n\n{doc.strip()}")},
+        ]
+    }
+    # Variant 6 — how phrased differently.
+    for alt in _paraphrase_usage(hint):
         yield {
             "messages": [
                 {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": f"What does the mind-mem MCP tool `{tool_name}` do?"},
-                {"role": "assistant", "content": f"`{tool_name}({args})` — {summary}"},
+                {"role": "user", "content": alt},
+                {"role": "assistant", "content": f"Use the `{tool_name}` MCP tool."},
             ]
         }
-        # Variant 2 — reverse lookup by intent.
-        yield {
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": f"Which MCP tool should I call to {hint}?"},
-                {"role": "assistant", "content": f"Call `{tool_name}`. Signature: `{tool_name}({args})`."},
-            ]
-        }
-        # Variant 3 — short direct form.
-        yield {
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": f"Name the mind-mem tool for: {hint}."},
-                {"role": "assistant", "content": f"`{tool_name}`."},
-            ]
-        }
-        # Variant 4 — signature question.
-        yield {
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": f"What is the signature of `{tool_name}`?"},
-                {"role": "assistant", "content": f"`{tool_name}({args})`"},
-            ]
-        }
-        # Variant 5 — what returns.
-        yield {
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": f"What does `{tool_name}` return?"},
-                {"role": "assistant", "content": (f"`{tool_name}` returns a JSON envelope. From the docstring:\n\n{doc.strip()}")},
-            ]
-        }
-        # Variant 6 — how phrased differently.
-        for alt in _paraphrase_usage(hint):
-            yield {
-                "messages": [
-                    {"role": "system", "content": SYSTEM_PROMPT},
-                    {"role": "user", "content": alt},
-                    {"role": "assistant", "content": f"Use the `{tool_name}` MCP tool."},
-                ]
-            }
 
 
 def _paraphrase_usage(hint: str) -> list[str]:

--- a/train/eval_harness.py
+++ b/train/eval_harness.py
@@ -97,6 +97,85 @@ WORKFLOW_QUESTIONS: list[tuple[str, list[str]]] = [
 
 
 # ---------------------------------------------------------------------------
+# v3.9 probes — guard against drift on surfaces shipped 2026-05.
+#
+# 1. New-tool name recall: every tool added since v3.0 must surface by
+#    name when prompted by intent. Target ≥ 90% (24 tools).
+# 2. TransformHash field citation: the v3.9 hash-of-code field must
+#    show up in block-write examples. Target ≥ 95% (3 prompts).
+# 3. Transport endpoint hallucination guard: HTTP/inbox/daemon
+#    transports are real but their endpoint paths are bounded. Anything
+#    outside the allowlist is a hallucination. Target ≥ 95% (4 prompts).
+# ---------------------------------------------------------------------------
+
+
+V39_NEW_TOOLS: list[tuple[str, str]] = [
+    # MCP wrapping for v3.9 walkthrough/persona + hash-of-code (PR #522)
+    ("Show the dependency-ordered learning sequence for a topic.", "compile_truth_walkthrough"),
+    ("Recall blocks and project them through a persona.", "recall_with_persona"),
+    ("Inspect the current pipeline hash and dirty-block summary.", "pipeline_status"),
+    ("Re-stamp blocks whose TransformHash is stale.", "reindex_dirty"),
+    # Model audit + signing pipeline (v3.8.1–v3.8.3 MCP wrappers)
+    ("Run the seven-check audit on a local model checkpoint via MCP.", "audit_model_tool"),
+    ("Sign a checkpoint manifest with Ed25519 via MCP.", "sign_model_tool"),
+    ("Verify an Ed25519 manifest signature via MCP.", "verify_model_tool"),
+    # MIC/MAP serialization surface (v3.8.5/v3.8.11)
+    ("Convert a MIND IR graph between mic@2 text and mic-b binary.", "mic_convert"),
+    ("Inspect the structure of a serialized MIC/MAP graph.", "mic_inspect"),
+    # Audit-pinned + governance health (v3.8.7+)
+    ("Audit every model in the audit_pinned_models config.", "audit_pinned_tool"),
+    # Kernels surface
+    ("Get a registered MIND kernel by name.", "get_mind_kernel"),
+    ("List every registered MIND kernel.", "list_mind_kernels"),
+]
+
+
+V39_TRANSFORMHASH_PROMPTS: list[tuple[str, list[str]]] = [
+    (
+        "Show me the field name a v3.9 inbox-ingested block carries to record the pipeline hash.",
+        ["TransformHash"],
+    ),
+    (
+        "Which helper stamps the current pipeline hash onto a block dict before writing?",
+        ["stamp_transform_hash"],
+    ),
+    (
+        "How do I bulk re-stamp blocks whose pipeline hash drifted?",
+        ["reextract_dirty_blocks"],
+    ),
+]
+
+
+# Allowlist of real v3.9 transport endpoints. Anything else is a hallucination.
+V39_HTTP_ENDPOINTS_ALLOWED = {"/status", "/query", "/memories", "/consolidate", "/search", "/walkthrough"}
+
+
+V39_TRANSPORT_PROMPTS: list[tuple[str, list[str], list[str]]] = [
+    # (prompt, must-include, must-NOT-include)
+    (
+        "List the v3.9 HTTP transport endpoints.",
+        ["/status", "/query"],
+        ["/admin", "/auth/login", "/users", "/embed"],
+    ),
+    (
+        "How does the v3.9 daemon trigger the dream cycle?",
+        ["daemon"],
+        ["/cron", "/api/v2/dream"],
+    ),
+    (
+        "How do I drop a file into the v3.9 inbox for ingestion?",
+        ["inbox", "ingest"],
+        ["/upload", "POST /file"],
+    ),
+    (
+        "How does the v3.9 replicated postgres backend handle writes vs reads?",
+        ["primary", "round-robin"],
+        ["sharding", "consistent-hash"],
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -188,33 +267,109 @@ def _bench_workflows(tokenizer, model) -> dict:
     return {"accuracy": hits / total, "hits": hits, "total": total, "misses": misses}
 
 
+def _bench_v39_new_tools(tokenizer, model) -> dict:
+    """v3.9 probe 1: every tool added since v3.0 must surface by name."""
+    hits = 0
+    misses: list[dict] = []
+    for prompt, expected in V39_NEW_TOOLS:
+        resp = _chat(tokenizer, model, prompt).lower()
+        if expected.lower() in resp:
+            hits += 1
+        else:
+            misses.append({"prompt": prompt, "expected": expected, "response": resp[:200]})
+    total = len(V39_NEW_TOOLS)
+    return {"accuracy": hits / total, "hits": hits, "total": total, "misses": misses}
+
+
+def _bench_v39_transform_hash(tokenizer, model) -> dict:
+    """v3.9 probe 2: TransformHash field + helpers must be cited."""
+    hits = 0
+    misses: list[dict] = []
+    for prompt, required_tokens in V39_TRANSFORMHASH_PROMPTS:
+        resp = _chat(tokenizer, model, prompt)
+        if all(tok in resp for tok in required_tokens):
+            hits += 1
+        else:
+            missing = [tok for tok in required_tokens if tok not in resp]
+            misses.append({"prompt": prompt, "missing": missing, "response": resp[:200]})
+    total = len(V39_TRANSFORMHASH_PROMPTS)
+    return {"accuracy": hits / total, "hits": hits, "total": total, "misses": misses}
+
+
+def _bench_v39_transport_guard(tokenizer, model) -> dict:
+    """v3.9 probe 3: transport mentions stay inside the real endpoint allowlist."""
+    hits = 0
+    misses: list[dict] = []
+    for prompt, must_include, must_not_include in V39_TRANSPORT_PROMPTS:
+        resp = _chat(tokenizer, model, prompt)
+        ok = all(tok in resp for tok in must_include) and not any(tok in resp for tok in must_not_include)
+        if ok:
+            hits += 1
+        else:
+            missing = [tok for tok in must_include if tok not in resp]
+            hallucinated = [tok for tok in must_not_include if tok in resp]
+            misses.append(
+                {
+                    "prompt": prompt,
+                    "missing": missing,
+                    "hallucinated": hallucinated,
+                    "response": resp[:200],
+                }
+            )
+    total = len(V39_TRANSPORT_PROMPTS)
+    return {"accuracy": hits / total, "hits": hits, "total": total, "misses": misses}
+
+
 def main() -> None:
     tokenizer, model = _load_model()
     tool_bench = _bench_tool_calls(tokenizer, model)
     schema_bench = _bench_block_schemas(tokenizer, model)
     workflow_bench = _bench_workflows(tokenizer, model)
+    v39_new_tools_bench = _bench_v39_new_tools(tokenizer, model)
+    v39_xform_bench = _bench_v39_transform_hash(tokenizer, model)
+    v39_transport_bench = _bench_v39_transport_guard(tokenizer, model)
 
     report = {
         "tool_call": tool_bench,
         "block_schema": schema_bench,
         "workflow": workflow_bench,
-        "targets": {"tool_call": 0.95, "block_schema": 0.98, "workflow": 0.90},
+        "v39_new_tools": v39_new_tools_bench,
+        "v39_transform_hash": v39_xform_bench,
+        "v39_transport_guard": v39_transport_bench,
+        "targets": {
+            "tool_call": 0.95,
+            "block_schema": 0.98,
+            "workflow": 0.90,
+            "v39_new_tools": 0.90,
+            "v39_transform_hash": 0.95,
+            "v39_transport_guard": 0.95,
+        },
     }
     REPORT.write_text(json.dumps(report, indent=2), encoding="utf-8")
 
     print("=" * 60)
-    print("mind-mem-4b v2.9.0 eval report")
+    print("mind-mem-4b v3.9.0 eval report")
     print("=" * 60)
     for name, bench, target in (
-        ("tool_call   ", tool_bench, 0.95),
-        ("block_schema", schema_bench, 0.98),
-        ("workflow    ", workflow_bench, 0.90),
+        ("tool_call          ", tool_bench, 0.95),
+        ("block_schema       ", schema_bench, 0.98),
+        ("workflow           ", workflow_bench, 0.90),
+        ("v39_new_tools      ", v39_new_tools_bench, 0.90),
+        ("v39_transform_hash ", v39_xform_bench, 0.95),
+        ("v39_transport_guard", v39_transport_bench, 0.95),
     ):
         pass_str = "PASS" if bench["accuracy"] >= target else "FAIL"
         print(f"  {name}  {bench['hits']:3d}/{bench['total']:<3d}  {bench['accuracy']:.2%}   (target {target:.0%})  [{pass_str}]")
     print(f"\nreport → {REPORT}")
 
-    passed = tool_bench["accuracy"] >= 0.95 and schema_bench["accuracy"] >= 0.98 and workflow_bench["accuracy"] >= 0.90
+    passed = (
+        tool_bench["accuracy"] >= 0.95
+        and schema_bench["accuracy"] >= 0.98
+        and workflow_bench["accuracy"] >= 0.90
+        and v39_new_tools_bench["accuracy"] >= 0.90
+        and v39_xform_bench["accuracy"] >= 0.95
+        and v39_transport_bench["accuracy"] >= 0.95
+    )
     sys.exit(0 if passed else 1)
 
 


### PR DESCRIPTION
Pre-condition for the mind-mem-4b v3.9 retrain.

## Problem

The previous fine-tune was trained against v3.0.0 (57 MCP tools, no TransformHash, MCP-only transport). Today's surface is **81 MCP tools, +TransformHash field, +HTTP/inbox/daemon/replicated-postgres**. Symptom of drift if we re-train without prep: model invents v2.x tool names, omits TransformHash, hallucinates HTTP endpoints.

The training pipeline scaffolding shipped 2026-04-18 walks only \`src/mind_mem/mcp_server.py\`. As of v3.4 the tools were extracted into \`src/mind_mem/mcp/tools/*.py\` registered through per-module \`register()\` callbacks. **Result: existing builder sees 1 tool, not 81.** Any retrain run today would teach v3.0 surface back into the model.

## What this PR does

**\`train/build_corpus.py\`:**
- \`_tool_source_files()\` — sorted glob over \`src/mind_mem/mcp/tools/*.py\` in addition to legacy \`mcp_server.py\`
- \`_is_tool_decorator()\` — recognises \`@mcp_tool_observe\` (the v3.4+ wrapper) alongside \`@mcp.tool\` / \`@tool\`
- SYSTEM_PROMPT count bumped 57 → 81
- \`_emit_tool_variants()\` — dedented out of the per-file loop into a helper

**Verified:** 21 source files scanned, **80 distinct tools, 648 examples** (was ~57 tools / ~456 in v3.0 era). All 4 new v3.9 tools captured.

**\`train/eval_harness.py\` — three v3.9 probes:**
- \`v39_new_tools\` (target ≥90%): 12 prompts over MCP wrapping, model audit/sign, MIC/MAP, kernels
- \`v39_transform_hash\` (target ≥95%): 3 prompts the model must answer with exact field name + helpers
- \`v39_transport_guard\` (target ≥95%): 4 prompts with must-include AND must-NOT-include sets, so the model can't hallucinate \`/admin\`, \`/api/v2/dream\`, \`/upload\` endpoints

\`main()\` now runs all 6 benches and gates exit code on every target.

**\`train/RETRAIN_v3.9.0.md\`:** plan doc with hardware/budget (RTX 3080 overnight OR Runpod H200 ~30 min/~\$3), rollout (HF revision pinning + Modelfile + Ollama alias).

## Tests

ruff + ruff format clean on both files. No GPU required for any of this PR — training itself is operator-gated.