### PR TITLE
feat: v4.0.15 — MindLLM backend + token rotation + time-bounded recall + companion-tools + N-08/T-007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,127 @@
 
 All notable changes to MIND-Mem are documented in this file.
 
+## v4.0.15 — MindLLM backend + token rotation + time-bounded recall + companion-tools + N-08/T-007
+
+Released 2026-05-20.
+
+Five-item roadmap-cluster release closing one or more genuinely-open items
+across federation hardening, Group E (compliance), Group G (ecosystem),
+and the 2026-04-28 security audit remainders.
+
+### Added — MindLLM backend (`mindllm`) for OpenAI-compatible inference
+
+mind-mem now treats [STARGA MindLLM](https://github.com/star-ga/MindLLM)
+as a first-class LLM backend alongside Ollama / vLLM / openai-compatible.
+MindLLM is STARGA's local, governed, **deterministic** inference server
+written in pure MIND, exposing OpenAI-compatible endpoints
+(`/v1/chat/completions`, `/v1/completions`, `/v1/models`, `/health`)
+plus a first-party RFN classifier endpoint.
+
+- `backend="mindllm"` (also accepts `mind-llm` / `mind_llm` aliases) in
+  `mind-mem.json` or `MIND_MEM_LLM_BACKEND=mindllm` in the environment.
+- Default URL `http://localhost:8080/v1`; override via `MIND_MEM_MINDLLM_URL`.
+- `auto`-discovery probes MindLLM **before** vLLM, so deployments
+  running MindLLM are picked up without explicit configuration.
+- `pipeline_hash._BACKEND_SOURCE_FILES` recognises `mindllm` as a known
+  backend (not the unknown-backend stub hash).
+
+Differentiator vs Ollama/vLLM: bit-identical output across runs (Q16.16
+evidence path + deterministic-reduction kernels) and a per-token
+cryptographic evidence chain. mind-mem treats it as just another
+OpenAI-compatible endpoint at the wire level — the value-add is the
+deterministic + evidence-chain guarantees. 6 new regression tests.
+
+### Added — Token rotation primitive (roadmap v4.0.x federation hardening)
+
+Closes the 3rd of 4 federation transport hardening gaps.
+
+- `MIND_MEM_TOKENS` (comma-separated) supports **N-of-K active tokens**
+  with a grace window during rotation. The HTTP transport reads it on
+  every request — no restart required when tokens change.
+- New CLI: `mm token rotate [--length 24] [--grace-seconds 86400]`
+  mints a fresh url-safe token (192-bit entropy) and emits the shell
+  export statement plus operator instructions. New token is canonical
+  going forward; old tokens stay valid through the grace window so
+  in-flight clients don't break.
+- Backwards compatible: deployments using the existing single-token
+  `MIND_MEM_TOKEN` env var keep working unchanged. Adding the new env
+  is opt-in.
+- 11 new regression tests covering env-var precedence, grace-window
+  preservation, single-token fallback, entropy floor, CLI wiring.
+
+### Added — Time-bounded recall (`since` / `until` ISO-8601 filters)
+
+Closes the first of three time-related items in Group E (compliance).
+
+- `recall(workspace, query, *, since="2026-01-01", until="2026-12-31")`
+  filters returned hits by block `Date` field. Comparison is string-
+  based on ISO-8601 so `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, and full
+  timestamps all work because lexical and chronological ordering
+  coincide on ISO-8601.
+- Filtering is **post-rank** — applied after BM25 + vector + RRF +
+  reranker — so the ranking quality the reranker provides is preserved
+  for the in-range subset.
+- New CLI flags: `mm recall <query> --since YYYY-MM-DD --until YYYY-MM-DD`.
+- 18 new regression tests covering helper invariants, end-to-end
+  filtering, bound semantics (inclusive), impossible ranges, CLI flag
+  wiring. `event_id` filter from the original roadmap entry is deferred
+  to v4.0.16 — needs the event-store hook design pass first.
+
+### Added — Companion-tools documentation (MindLLM + GitNexus)
+
+- New `docs/companion-tools.md` with the canonical positioning for
+  mind-mem ↔ MindLLM (first-class backend) and mind-mem ↔ GitNexus
+  (sibling MCP server, orthogonal scope — "code structure today" vs
+  "decision history over time"). License + integration recipe for each.
+- README's "Deep-dive docs" list now points at it; `mind-mem-4b-setup.md`
+  entry updated to mention MindLLM alongside Ollama / vLLM / etc.
+
+### Added — `decrypt_file` forensic audit trail (alert N-08)
+
+Closes the 2026-04-28 audit `N-08` item.
+
+- Every successful `decrypt_file` MCP-tool call appends a JSON-line
+  to `memory/decrypted_files.jsonl` carrying `ts` (ISO-8601 UTC) +
+  `path` + `actor` (from the agent-id ContextVar, defaults to
+  `anonymous` for direct callers) + `mode` (`read` for `decrypt_file`,
+  `in_place` reserved for `decrypt_file_in_place`).
+- Append failures are logged but never block the legitimate decrypt
+  (forensic audit is depth-in-defence, not a DoS vector).
+- Pair with the new T-007 operator runbook (below) for OS-level
+  immutability of the trail. 4 new regression tests.
+
+### Docs — Append-only audit-log runbook (closes T-007)
+
+Closes the 2026-04-28 audit `T-007` item with an operator-side runbook
+rather than runtime code: `docs/append-only-audit-logs.md`. Covers:
+
+- Linux `chattr +a` (works on ext2/3/4, btrfs, xfs; not on NFS/SMB).
+- macOS `chflags uappnd` (USR_APPEND).
+- Windows `icacls` (NTFS `FILE_APPEND_DATA` grant + `FILE_WRITE_DATA`
+  deny pattern; or forward to a WORM store).
+- Rotation pattern that survives the immutability attribute.
+- Threat-model alignment: closes post-compromise tampering of the
+  forensic JSONL files; the hash-chain layer remains the primary
+  integrity signal.
+
+### Green-gate
+
+- 5152+ tests pass non-stress (+39 new across the 5 items).
+- ruff check + ruff format clean on changed files.
+- mypy clean on changed surfaces.
+- Open code-scanning alerts: **0** (carried clean from v4.0.14).
+
+### Deferred from v4.0.15 (still tracked in ROADMAP)
+
+- `event_id` filter on `recall(...)` — needs event-store hook design.
+- Block versioning + time-travel (`as_of=date`, `block_history()`) —
+  audit chain has the data; needs the query API surface.
+- OpenAPI / AsyncAPI specs export — single source of truth for SDK
+  generation; chunk-of-work item, not 1-day.
+- Per-peer identity binding (token → agent_id table + signed-write
+  envelopes) — needs schema + key-management design pass.
+
 ## v4.0.14 — ROADMAP honesty pass + audit headers + federation peer allowlist
 
 Released 2026-05-20.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ Output:
 - [`docs/setup.md`](docs/setup.md) — install, configure, wire MCP, opt in to MIND native kernels
 - [`docs/usage.md`](docs/usage.md) — every surface (MCP tools by category, `mm` CLI, `mind-mem-verify`, Python library) with worked examples
 - [`docs/client-integrations.md`](docs/client-integrations.md) — **17 AI client integrations** (Claude Code, Codex, Vibe, Gemini, Cursor, Windsurf, aider, OpenClaw, NanoClaw, NemoClaw, Continue, Cline, Roo, Zed, Copilot, Cody, Qodo) with `mm install-all` auto-detection
-- [`docs/mind-mem-4b-setup.md`](docs/mind-mem-4b-setup.md) — download + run the `star-ga/mind-mem-4b` full-FT model locally (transformers, exllamav2, vLLM, llama.cpp, Ollama)
-- [`ROADMAP.md`](ROADMAP.md) — feature roadmap (all 282 v2.x checkboxes closed in v2.8.0)
+- [`docs/mind-mem-4b-setup.md`](docs/mind-mem-4b-setup.md) — download + run the `star-ga/mind-mem-4b` full-FT model locally (transformers, exllamav2, vLLM, llama.cpp, Ollama, **MindLLM**)
+- [`docs/companion-tools.md`](docs/companion-tools.md) — **companion tools** that complement (not compete with) mind-mem: [MindLLM](https://github.com/star-ga/MindLLM) for deterministic + evidence-chained inference, [GitNexus](https://github.com/h4ckf0r0day/GitNexus) for code knowledge-graph
+- [`ROADMAP.md`](ROADMAP.md) — feature roadmap (genuinely-open items at the top; bulk of v3.2.0→v4.0.0 shipped)
 - [`CHANGELOG.md`](CHANGELOG.md) — release notes for every published version
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,12 +20,12 @@ Surfaced at the top so the actual remaining work is visible without
 scrolling 1500 lines of historical sections. Each item is followed
 by its full description below.
 
-### Group D — Network hardening (5 items)
+### Group D — Network hardening (3 items; +1 shipped in v4.0.14)
 
 - [ ] **TLS 1.3 minimum + cert pinning** on REST / gRPC / MCP-HTTP
 - [ ] **mTLS for service-to-service** between mind-mem nodes
 - [ ] **Public / private workspaces** (`workspace.mode = public | private | mixed`)
-- [ ] **Audit headers** propagated through REST + gRPC (`X-MindMem-Request-Id`, `X-MindMem-Actor`, `X-MindMem-Purpose`)
+- [x] **Audit headers** (`X-MindMem-Request-Id`, `X-MindMem-Actor`, `X-MindMem-Purpose`) — **shipped v4.0.14** (REST middleware; gRPC parity TODO when gRPC surface gets the same treatment)
 - [ ] **ActivityPub federation interop** (optional bridge; low priority)
 
 ### Group B — Knowledge graph (2 items)
@@ -68,11 +68,11 @@ by its full description below.
 - [ ] **`PostgresBlockStore.snapshot(snap_id=…)`** — current signature still requires filesystem path; cross-host PG snapshots blocked
 - [ ] **T-004 webhook allowlist + T-001 content-provenance tags + N-08/N-12/N-13/T-007** — minor security-hardening items (see v3.2.0 section)
 
-### v4.0.x federation transport hardening (4 items)
+### v4.0.x federation transport hardening (3 items; +1 shipped in v4.0.14)
 
 - [ ] **Per-peer identity beyond bearer token** (token → agent_id binding, signed-write envelopes)
 - [ ] **mTLS + cert pinning on `FederationClient`**
-- [ ] **Operator-side peer allowlist** (`MIND_MEM_FED_PEERS=10.0.0.5,…`)
+- [x] **Operator-side peer allowlist** (`MIND_MEM_FED_PEERS=10.0.0.5,…`) — **shipped v4.0.14**
 - [ ] **Token rotation primitive** (N-of-K active tokens, `mm token rotate`)
 
 ### Cross-cutting (deferred infrastructure)

--- a/docs/append-only-audit-logs.md
+++ b/docs/append-only-audit-logs.md
@@ -1,0 +1,152 @@
+# Append-Only Audit Logs — Operator Runbook
+
+> Closes audit item **T-007** (roadmap v4.0.15, deferred from the
+> 2026-04-28 STRIDE audit pass). The mind-mem audit chain already
+> detects tampering via hash-chain verification; this runbook makes
+> tampering **physically impossible without root** by applying the
+> OS-level append-only attribute to the on-disk audit files.
+
+## What gets append-only
+
+mind-mem writes three forensic audit trails as JSON-lines files:
+
+| File                                 | Purpose                                  | Added in |
+|--------------------------------------|------------------------------------------|----------|
+| `memory/deleted_blocks.jsonl`        | `delete_memory_item` deletion receipts   | v3.0.x   |
+| `memory/decrypted_files.jsonl`       | `decrypt_file` admin-tool forensic trail | v4.0.15  |
+| `memory/audit.log` (chained)         | Hash-chained governance write events     | v2.x     |
+
+All three follow the same append-only pattern: `O_APPEND` writes,
+no in-place edits, JSON-per-line so partial-write resumption is
+trivial. Applying the OS attribute is the **second** layer of
+defence (hash chain is the first).
+
+## Linux — `chattr +a`
+
+```bash
+# As root, after the workspace is initialised (the file must exist
+# before the attribute is set; mind-mem touches each file on first
+# write):
+sudo chattr +a /path/to/workspace/memory/deleted_blocks.jsonl
+sudo chattr +a /path/to/workspace/memory/decrypted_files.jsonl
+sudo chattr +a /path/to/workspace/memory/audit.log
+```
+
+After this:
+
+* `O_APPEND` writes from mind-mem keep working.
+* Any process attempting an in-place rewrite (truncate, seek + write,
+  open with `O_WRONLY` without `O_APPEND`) gets `EPERM` — even root.
+* `unlink()` fails with `EPERM`. The file can only be removed after
+  the operator does `chattr -a`.
+
+**Filesystem requirements:** ext2/3/4, btrfs, xfs (with chattr
+support). Network filesystems (NFS, SMB) and tmpfs typically do not
+honor `+a` — for those, terminate the chain at a host-local volume
+mount.
+
+**Verify:**
+
+```bash
+lsattr /path/to/workspace/memory/decrypted_files.jsonl
+# Should show ``-----a-------e------- /path/...`` (the ``a`` flag).
+```
+
+## macOS — `chflags uappnd`
+
+```bash
+# User-level immutable + append-only flag (USR_APPEND). Survives
+# normal writes via O_APPEND; blocks every other mutation including
+# unlink unless the operator clears the flag.
+sudo chflags uappnd /path/to/workspace/memory/deleted_blocks.jsonl
+sudo chflags uappnd /path/to/workspace/memory/decrypted_files.jsonl
+sudo chflags uappnd /path/to/workspace/memory/audit.log
+```
+
+To verify: `ls -lO /path/to/workspace/memory/` — the `uappnd` flag
+appears in the output.
+
+**System Integrity Protection note:** SIP-protected paths are not
+required; user-volume application of `uappnd` is sufficient and
+honored by all standard `open(2)` calls.
+
+## Windows
+
+Windows lacks a direct equivalent. Two options:
+
+1. **NTFS ACLs:** grant `FILE_APPEND_DATA` only, deny `FILE_WRITE_DATA`
+   on the audit files. `mind-mem` opens with `O_APPEND` which maps to
+   `FILE_APPEND_DATA`; the deny on `FILE_WRITE_DATA` blocks every
+   other mutation. Requires `icacls /grant` + `/deny` setup as
+   Administrator.
+
+2. **Forward to a WORM store:** redirect the audit JSONL files to a
+   Windows-side WORM volume (e.g., a write-once SMB share, an
+   Object Lock S3-compatible target via `rclone mount`, or a
+   commercial WORM file system). This is the recommended pattern
+   for compliance deployments.
+
+`icacls` example (Administrator PowerShell):
+
+```powershell
+$path = "C:\path\to\workspace\memory\decrypted_files.jsonl"
+icacls $path /inheritance:r
+icacls $path /grant:r "SYSTEM:(F)"
+icacls $path /grant:r "mind-mem-service:(WD,AD)"   # write + append data
+icacls $path /deny    "mind-mem-service:(WD)"      # deny in-place write
+```
+
+## When to apply
+
+Apply **after** the workspace has been initialised and you have
+verified the audit chain integrity at least once (`mm scan
+--verify-chain`). Re-applying after a chain repair requires
+`chattr -a` / `chflags nouappnd` first.
+
+## Rotation / log-bomb concern
+
+The audit files grow unbounded. For long-lived deployments,
+**rotate** rather than truncate:
+
+```bash
+# Periodic (e.g. weekly cron) rotation.
+sudo chattr -a /path/to/workspace/memory/decrypted_files.jsonl
+mv /path/to/workspace/memory/decrypted_files.jsonl \
+   /path/to/workspace/memory/decrypted_files.jsonl.$(date +%Y%m%d)
+touch /path/to/workspace/memory/decrypted_files.jsonl
+sudo chattr +a /path/to/workspace/memory/decrypted_files.jsonl
+# Optionally re-apply +a to the rotated file so historical records
+# are also tamper-evident:
+sudo chattr +a /path/to/workspace/memory/decrypted_files.jsonl.$(date +%Y%m%d)
+```
+
+Truncating the live file is intentionally blocked; rotate-and-touch
+is the supported path. Same pattern on macOS with `chflags`.
+
+## Verification suite
+
+After applying, run:
+
+```bash
+mm doctor --verify-audit-immutability   # roadmap v4.1.0 — not yet shipped
+```
+
+Today (v4.0.15), verify manually:
+
+```bash
+# Linux: ``a`` flag should be present.
+lsattr /path/to/workspace/memory/*.jsonl
+
+# Try an in-place write — must fail with EPERM.
+echo "tamper" > /path/to/workspace/memory/decrypted_files.jsonl
+# bash: ...: Operation not permitted   ← correct behaviour
+```
+
+## Threat model alignment
+
+This runbook closes the post-compromise tampering vector: a malicious
+process that gains the mind-mem service's UID can write new audit
+records (via `O_APPEND`) but cannot erase or rewrite historical ones.
+It does **not** stop the service itself from writing falsified
+records into the chain; that's the hash-chain layer's job. The two
+layers are independent.

--- a/docs/companion-tools.md
+++ b/docs/companion-tools.md
@@ -1,0 +1,102 @@
+# Companion Tools
+
+External tools that solve adjacent memory/inference problems
+mind-mem deliberately does not solve. Documented here so users see
+them as **complements**, not competitors. mind-mem **does not depend
+on any of these** — license, scope, and substrate-of-record concerns
+make co-existence the right pattern.
+
+## MindLLM — pure-MIND deterministic inference (STARGA)
+
+[`star-ga/MindLLM`](https://github.com/star-ga/MindLLM) is STARGA's
+local, governed, **deterministic** inference server written in pure
+MIND. It exposes OpenAI-compatible endpoints
+(`/v1/chat/completions`, `/v1/completions`, `/v1/models`, `/health`)
+plus a first-party RFN (Resonance Field Network) classifier endpoint
+(`/v1/rfn/classify`).
+
+mind-mem treats MindLLM as a first-class LLM backend (alongside
+Ollama and vLLM). Set `backend: "mindllm"` in `mind-mem.json` or
+`MIND_MEM_LLM_BACKEND=mindllm` in the environment; mind-mem will
+talk to `http://localhost:8080/v1` by default (override with
+`MIND_MEM_MINDLLM_URL`).
+
+**Why pick MindLLM over Ollama/vLLM for mind-mem workloads:**
+
+| Property                                    | Ollama / vLLM       | MindLLM             |
+| ------------------------------------------- | ------------------- | ------------------- |
+| Bit-identical output, same GPU              | no                  | **yes** (Q16.16 evidence path + deterministic-reduction kernels) |
+| Per-token cryptographic evidence chain      | no                  | **yes** |
+| Compiled governance constraints (I11–I15)   | no                  | **yes** (via 512-mind) |
+| Mid-request detection of silent reconfig    | no                  | **yes** (HOLD→RESUME) |
+| Raw tokens/sec advantage vs vLLM            | —                   | **±10%** at best |
+
+mind-mem's `mind-mem-4b` retrieval-helper model runs equally on
+Ollama or MindLLM at the protocol layer; the deterministic +
+evidence-chain guarantees that MindLLM adds are what differentiate
+audit-grade deployments from best-effort ones.
+
+**Quick start (mind-mem ↔ MindLLM):**
+
+```bash
+# 1. Build MindLLM (requires mind-inference + 512-mind siblings —
+#    see https://github.com/star-ga/MindLLM Quick start).
+git clone https://github.com/star-ga/MindLLM ~/MindLLM
+cd ~/MindLLM && make build && ./build/MindLLM serve --port 8080 &
+
+# 2. Point mind-mem at it.
+export MIND_MEM_LLM_BACKEND=mindllm
+# (optional override) export MIND_MEM_MINDLLM_URL=http://localhost:8080/v1
+
+# 3. Verify reachability.
+mm doctor
+```
+
+mind-mem's existing `auto`-discovery order also probes MindLLM at
+`localhost:8080` before vLLM at `localhost:8000`, so deployments
+that already run MindLLM are picked up with zero config.
+
+## GitNexus — code knowledge-graph indexer (third-party, MCP)
+
+[`h4ckf0r0day/GitNexus`](https://github.com/h4ckf0r0day/GitNexus)
+is a code knowledge-graph indexer exposed as an MCP server. It
+parses repo structure (call graphs, dependencies, clusters) and
+serves architectural-awareness tools to coding agents.
+
+**What it solves vs what mind-mem solves:**
+
+| Question                                    | Tool                 |
+| ------------------------------------------- | -------------------- |
+| "what does the code do at this point in time" | **GitNexus** |
+| "what did we decide and why, over time"    | **mind-mem** |
+
+The two are orthogonal — code structure today vs governed decision
+history. License: **PolyForm Noncommercial**, incompatible with
+mind-mem's Apache-2.0 as a programmatic dependency.
+
+**Recommendation:** install GitNexus as a separate MCP server
+alongside mind-mem. Both end up in your Claude Code / Cursor /
+Windsurf / Zed MCP lists — no integration code required.
+
+```bash
+# GitNexus install (per its own README — typical pattern):
+git clone https://github.com/h4ckf0r0day/GitNexus
+# follow upstream install + MCP-registration instructions
+
+# mind-mem install (Apache-2.0, this repo):
+pip install "mind-mem[all]"
+mm install-all  # auto-wires MCP for Claude Code, Cursor, Windsurf, ...
+```
+
+Both tools then appear in your MCP client's tool list and answer
+their respective question domains side-by-side.
+
+---
+
+## Out of scope here
+
+This document only covers tools mind-mem can be configured to
+**talk to** (MindLLM as a backend) or that share a **deployment
+pattern** (GitNexus as a sibling MCP server). For mind-mem's
+internal architecture — block schema, recall pipeline, governance
+engine, federation — see `ARCHITECTURE.md` and `ROADMAP.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mind-mem"
-version = "4.0.14"
+version = "4.0.15"
 description = "Drop-in memory for Claude Code, OpenClaw, and any MCP-compatible agent."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/mind_mem/__init__.py
+++ b/src/mind_mem/__init__.py
@@ -43,7 +43,7 @@ from .protection import (
 )
 from .storage import get_block_store
 
-__version__ = "4.0.14"
+__version__ = "4.0.15"
 
 # Best-effort import-time integrity check. Fails open unless
 # MIND_MEM_INTEGRITY=strict, so editable installs and source checkouts

--- a/src/mind_mem/_recall_core.py
+++ b/src/mind_mem/_recall_core.py
@@ -229,6 +229,56 @@ class RecallBackend(ABC):
         ...
 
 
+def _block_date(hit: dict) -> str | None:
+    """Return the block's date as an ISO-8601 string, or None when absent.
+
+    Each hit carries the original ``Date:`` block field as either ``Date``
+    (verbatim case from markdown) or ``date`` (lowercased by some backends).
+    Returns whichever is present, stripped.
+    """
+    for key in ("Date", "date"):
+        v = hit.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def _in_date_range(
+    date_str: str | None,
+    since: str | None,
+    until: str | None,
+) -> bool:
+    """True iff ``date_str`` falls within ``[since, until]`` (inclusive).
+
+    Comparison is done at the ISO-8601 string level — works for
+    YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, and full timestamps because all
+    three sort lexicographically the same as chronologically.
+
+    A None bound means "open on that side"; a None ``date_str`` is
+    rejected (block has no date → cannot satisfy a date-bound query).
+    """
+    if since is None and until is None:
+        return True
+    if not date_str:
+        return False
+    if since and date_str < since:
+        return False
+    if until and date_str > until:
+        return False
+    return True
+
+
+def _apply_date_filter(
+    hits: list[dict],
+    since: str | None,
+    until: str | None,
+) -> list[dict]:
+    """Filter recall hits by ``Date`` field against [since, until]."""
+    if since is None and until is None:
+        return hits
+    return [h for h in hits if _in_date_range(_block_date(h), since, until)]
+
+
 @_traced("recall")
 def recall(
     workspace: str,
@@ -241,6 +291,9 @@ def recall(
     rerank: bool = True,
     rerank_debug: bool = False,
     include_pending: bool = False,
+    *,
+    since: str | None = None,
+    until: str | None = None,
     _allow_decompose: bool = True,
 ) -> list[dict]:
     """Search across all memory files using BM25 scoring. Returns ranked results.
@@ -256,6 +309,13 @@ def recall(
         rerank: Enable deterministic reranking (v7).
         rerank_debug: Log reranker feature breakdowns.
         include_pending: Include unreviewed SIGNALS.md proposals (default False).
+        since: ISO-8601 lower bound on block ``Date``; None = no lower bound.
+        until: ISO-8601 upper bound on block ``Date``; None = no upper bound.
+            Time-bounded recall (roadmap v4.0.0 Group E). Comparison is
+            string-based so ``YYYY-MM-DD`` and full timestamps both work.
+            Filtering is applied AFTER ranking + reranking — date is a
+            post-filter, not a retrieval-time prefilter, so the ranking
+            quality the reranker provides is preserved.
     """
     query_tokens = tokenize(query)
     if not query_tokens:
@@ -270,7 +330,7 @@ def recall(
     if _cfg_backend == "sqlite":
         from .sqlite_index import query_index
 
-        return query_index(
+        hits = query_index(
             workspace,
             query,
             limit=limit,
@@ -280,10 +340,15 @@ def recall(
             rerank=rerank,
             rerank_debug=rerank_debug,
         )
+        if since is not None or until is not None:
+            hits = _apply_date_filter(hits, since, until)[:limit]
+        return hits
     if isinstance(_cfg_backend, RecallBackend):
         try:
             backend_hits: list[dict] = _cfg_backend.search(workspace, query, limit=limit, active_only=active_only)
             if backend_hits:
+                if since is not None or until is not None:
+                    backend_hits = _apply_date_filter(backend_hits, since, until)[:limit]
                 return backend_hits
         except Exception as exc:
             _log.warning("recall_backend_error_fallback_to_scan", error=str(exc))
@@ -424,6 +489,8 @@ def recall(
             # Sort merged results by score descending, return up to limit
             all_merged = sorted(merged.values(), key=lambda r: (r["score"], r.get("_id", "")), reverse=True)
             _log.info("multihop_merged", total=len(all_merged), limit=limit, sub_queries=len(sub_queries))
+            if since is not None or until is not None:
+                all_merged = _apply_date_filter(all_merged, since, until)
             return all_merged[:limit]
 
     # Month normalization: inject numeric month tokens for date matching
@@ -1254,6 +1321,8 @@ def recall(
         except Exception as exc:
             _log.debug("intent_feedback_skipped", error=str(exc))
 
+    if since is not None or until is not None:
+        top = _apply_date_filter(top, since, until)[:limit]
     return top
 
 

--- a/src/mind_mem/http_transport.py
+++ b/src/mind_mem/http_transport.py
@@ -94,6 +94,39 @@ DEFAULT_RATE_MAX_CALLS = 120
 DEFAULT_RATE_WINDOW_SECS = 60
 MAX_TRACKED_CLIENTS = 1024  # LRU cap to bound limiter memory under attack
 
+
+# -- Token rotation primitive (roadmap v4.0.x) -----------------------------
+# ``MIND_MEM_TOKENS`` (comma-separated) supports N-of-K active tokens with
+# a grace window during rotation. Old single-token deployments keep using
+# ``MIND_MEM_TOKEN``; setting ``MIND_MEM_TOKENS`` overrides + extends.
+#
+# Rotation flow: operator runs ``mm token rotate``, which appends a new
+# token to ``MIND_MEM_TOKENS`` (the new one becomes the canonical write
+# token); old tokens stay valid through the grace window so in-flight
+# clients don't break, then the operator removes the old entry. Server
+# reads on every request (no restart needed).
+def _active_tokens(fallback: str | None = None) -> list[str]:
+    """Return the set of currently-active tokens.
+
+    Reads ``MIND_MEM_TOKENS`` (comma-separated) on every call so a
+    rotation via ``mm token rotate`` lands without restart. Falls
+    back to ``MIND_MEM_TOKEN`` (single-token deployments) and then
+    to the handler-bound *fallback* (the server's startup-time token).
+    Whitespace + empty entries are stripped.
+    """
+    multi = os.environ.get("MIND_MEM_TOKENS", "").strip()
+    if multi:
+        toks = [t.strip() for t in multi.split(",") if t.strip()]
+        if toks:
+            return toks
+    single = os.environ.get("MIND_MEM_TOKEN", "").strip()
+    if single:
+        return [single]
+    if fallback:
+        return [fallback]
+    return []
+
+
 # Endpoint paths — kept as constants so tests can import them.
 PATH_STATUS = "/status"
 PATH_QUERY = "/query"
@@ -788,17 +821,26 @@ def build_handler(
         def _authenticated(self) -> bool:
             if not auth_required:
                 return True
-            if token is None:
-                return False
             sent = self.headers.get(AUTH_HEADER, "")
-            # Constant-time comparison — see audit S-1. Plain `sent == token`
-            # short-circuits on first byte mismatch and leaks the token via
-            # response-latency timing on the loopback bind. hmac.compare_digest
-            # is constant-time over the longer string. The bool(sent) guard
-            # avoids the str-vs-str type mismatch path that would raise.
             if not sent:
                 return False
-            return hmac.compare_digest(sent, token)
+            # Token rotation (roadmap v4.0.x): accept any of an N-of-K
+            # active-tokens set. ``MIND_MEM_TOKENS`` (comma-separated)
+            # is preferred when set — supports grace-window rotation
+            # without restart. Falls back to the single ``token`` value
+            # the handler was built with for backwards compat.
+            #
+            # Read at request time so ``mm token rotate`` (which appends
+            # to MIND_MEM_TOKENS) takes effect for the next request
+            # without restarting the server.
+            active = _active_tokens(fallback=token)
+            if not active:
+                return False
+            # Constant-time comparison against EVERY active token (audit
+            # S-1). hmac.compare_digest short-circuits at the byte level
+            # internally; OR-ing the results across the set keeps the
+            # overall result constant-time-ish per token.
+            return any(hmac.compare_digest(sent, t) for t in active)
 
         # -- peer allowlist (roadmap v4.0.x federation hardening) -------
         def _peer_allowed(self) -> bool:

--- a/src/mind_mem/llm_extractor.py
+++ b/src/mind_mem/llm_extractor.py
@@ -107,12 +107,17 @@ def is_available(backend: str = "auto") -> bool:
         ``ollama``              local ollama daemon at :11434
         ``llama-cpp``           in-process llama-cpp-python
         ``vllm``                local vLLM OpenAI-compatible server
+        ``mindllm``             local MindLLM server (STARGA's pure-MIND
+                                deterministic-inference OpenAI-compatible
+                                endpoint; defaults to :8080/v1; see
+                                ``docs/companion-tools.md``)
         ``openai-compatible``   any OpenAI-compatible HTTP endpoint
         ``transformers``        in-process HF transformers (slowest)
         ``auto``                tries each in order until one answers
 
     Endpoint and base-url defaults read from env vars
-    (``MIND_MEM_LLM_BASE_URL``, ``MIND_MEM_VLLM_URL``).
+    (``MIND_MEM_LLM_BASE_URL``, ``MIND_MEM_VLLM_URL``,
+    ``MIND_MEM_MINDLLM_URL``).
     """
     if backend == "ollama":
         return _ollama_available()
@@ -120,6 +125,8 @@ def is_available(backend: str = "auto") -> bool:
         return _llama_cpp_available()
     if backend == "vllm":
         return _openai_compatible_available(_vllm_url())
+    if backend in ("mindllm", "mind-llm", "mind_llm"):
+        return _openai_compatible_available(_mindllm_url())
     if backend in ("openai-compatible", "openai_compatible"):
         return _openai_compatible_available(_oai_url())
     if backend == "transformers":
@@ -127,6 +134,7 @@ def is_available(backend: str = "auto") -> bool:
     if backend == "auto":
         return (
             _ollama_available()
+            or _openai_compatible_available(_mindllm_url())
             or _openai_compatible_available(_vllm_url())
             or _openai_compatible_available(_oai_url())
             or _llama_cpp_available()
@@ -137,6 +145,25 @@ def is_available(backend: str = "auto") -> bool:
 
 def _vllm_url() -> str:
     return os.environ.get("MIND_MEM_VLLM_URL", "http://localhost:8000/v1").rstrip("/")
+
+
+def _mindllm_url() -> str:
+    """MindLLM default endpoint.
+
+    MindLLM is STARGA's pure-MIND deterministic-inference HTTP server
+    exposing OpenAI-compatible endpoints (``/v1/chat/completions``,
+    ``/v1/completions``, ``/v1/models``, ``/health``) plus a first-party
+    RFN classifier endpoint (``/v1/rfn/classify``). Default port 8080
+    matches the upstream MindLLM convention; override with
+    ``MIND_MEM_MINDLLM_URL`` for non-default deployments.
+
+    Differentiator vs Ollama / vLLM: bit-identical output across runs
+    (Q16.16 evidence path + deterministic-reduction kernels) and a
+    per-token cryptographic evidence chain. See MindLLM README for
+    the full positioning table; mind-mem treats it as just another
+    OpenAI-compatible backend at the wire level.
+    """
+    return os.environ.get("MIND_MEM_MINDLLM_URL", "http://localhost:8080/v1").rstrip("/")
 
 
 def _oai_url() -> str:
@@ -358,7 +385,7 @@ def _query_llm(prompt: str, model: str, backend: str = "auto") -> str:
     Order for ``auto`` mode: ollama → vllm → openai-compat → llama-cpp →
     transformers. Each is tried until one returns a non-empty string.
     """
-    backends = [backend] if backend != "auto" else ["ollama", "vllm", "openai-compatible", "llama-cpp", "transformers"]
+    backends = [backend] if backend != "auto" else ["ollama", "mindllm", "vllm", "openai-compatible", "llama-cpp", "transformers"]
     for b in backends:
         try:
             if b == "ollama":
@@ -367,6 +394,8 @@ def _query_llm(prompt: str, model: str, backend: str = "auto") -> str:
                 out = _query_llama_cpp(prompt, model)
             elif b == "vllm":
                 out = _query_openai_compatible(prompt, model, _vllm_url())
+            elif b in ("mindllm", "mind-llm", "mind_llm"):
+                out = _query_openai_compatible(prompt, model, _mindllm_url())
             elif b in ("openai-compatible", "openai_compatible"):
                 out = _query_openai_compatible(prompt, model, _oai_url())
             elif b == "transformers":

--- a/src/mind_mem/mcp/tools/encryption.py
+++ b/src/mind_mem/mcp/tools/encryption.py
@@ -26,6 +26,59 @@ from ..infra.observability import mcp_tool_observe
 from ..infra.workspace import _workspace
 
 
+def _append_decrypt_audit(ws: str, path: str, *, mode: str) -> None:
+    """Append a forensic record of a decrypt operation to
+    ``memory/decrypted_files.jsonl`` (alert N-08, roadmap v4.0.15).
+
+    Pattern mirrors ``block_store._append_deletion_receipt``: append-only
+    JSONL with timestamp + path + actor (best-effort from agent_id
+    context) + mode (``read`` for ``decrypt_file``, ``in_place`` for
+    ``decrypt_file_in_place``). Failure to append is logged but does
+    not block the decrypt itself — forensic audit must be opportunistic,
+    never a denial-of-service vector for legitimate operators.
+
+    Pair with ``T-007`` operator runbook (see ``docs/security.md``)
+    which applies the OS-level append-only attribute (``chattr +a`` on
+    Linux, ``chflags uappnd`` on macOS) to this file so a compromised
+    process cannot edit the trail in-place.
+    """
+    import datetime as _dt
+
+    from mind_mem.observability import get_logger as _gl
+
+    log_dir = os.path.join(ws, "memory")
+    log_path = os.path.join(log_dir, "decrypted_files.jsonl")
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+        # Best-effort actor attribution — read from the agent-id
+        # ContextVar that ``mcp/infra/observability`` populates per call.
+        actor = "anonymous"
+        try:
+            from mind_mem.mcp.infra.observability import current_agent_id  # type: ignore
+
+            actor = current_agent_id.get("anonymous") or "anonymous"
+        except Exception:
+            pass
+        record = {
+            "ts": _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "path": path,
+            "actor": actor,
+            "mode": mode,
+        }
+        # O_APPEND keeps the trail atomic with respect to concurrent
+        # decrypt calls; ``chattr +a`` on the file then makes the
+        # append-only property OS-enforced (T-007).
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, sort_keys=True) + "\n")
+    except Exception as exc:  # nosec B110 — see rationale below.
+        # Audit append must not block the legitimate decrypt — log and
+        # continue. The decrypt event still appears in the structured
+        # ``files_decrypted`` metric counter + ``file_decrypted`` log
+        # emitted by ``encryption.py``; the JSONL trail is forensic
+        # depth-in-defence, not the primary signal.
+        _gl("mcp.encryption").warning("decrypt_audit_append_failed", path=path, error=str(exc))
+
+
 def _encryption_passphrase() -> str | None:
     """Fetch the at-rest encryption passphrase from env. None = disabled."""
     raw = os.environ.get("MIND_MEM_ENCRYPTION_PASSPHRASE", "").strip()
@@ -166,6 +219,10 @@ def decrypt_file(file_path: str) -> str:
         plaintext = EncryptionManager(ws, passphrase).decrypt_file(safe_path)
     except Exception as exc:
         return json.dumps({"error": f"decrypt failed: {exc}"})
+    # Append forensic audit record (N-08, roadmap v4.0.15). Mode is
+    # ``read`` because ``decrypt_file`` returns plaintext without
+    # mutating the on-disk ciphertext.
+    _append_decrypt_audit(ws, safe_path, mode="read")
     return json.dumps(
         {
             "_schema_version": MCP_SCHEMA_VERSION,

--- a/src/mind_mem/mm_cli.py
+++ b/src/mind_mem/mm_cli.py
@@ -43,7 +43,14 @@ def _workspace() -> str:
 def _cmd_recall(args: argparse.Namespace) -> int:
     from mind_mem.recall import recall
 
-    results = recall(_workspace(), args.query, limit=args.limit, active_only=args.active_only)
+    results = recall(
+        _workspace(),
+        args.query,
+        limit=args.limit,
+        active_only=args.active_only,
+        since=getattr(args, "since", None),
+        until=getattr(args, "until", None),
+    )
     print(json.dumps(results, indent=2, default=str))
     return 0
 
@@ -1822,6 +1829,70 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     return 0 if report.get("in_sync", False) or args.rebuild_cache or args.migrate_recall_log else 1
 
 
+def _cmd_token_rotate(args: argparse.Namespace) -> int:
+    """Mint a new federation/HTTP transport token and emit the rotation hint.
+
+    Token rotation primitive (roadmap v4.0.x federation hardening). The
+    HTTP transport reads ``MIND_MEM_TOKENS`` (comma-separated) on every
+    request, so appending a new token gives an immediate grace window
+    where both old and new tokens authenticate. After the grace window
+    closes the operator removes the old entry.
+
+    Output:
+        ``new_token``  — the freshly minted token (192-bit url-safe)
+        ``shell``      — the export statement the operator pastes to
+                          ROTATE NOW (appends new token; keeps old(s)
+                          for the grace window)
+        ``shell_final`` — the export statement after the grace window
+                          (drops the previous tokens)
+        ``grace_seconds`` — the configured / default grace window
+
+    The token itself is generated via ``secrets.token_urlsafe(24)`` —
+    24 url-safe bytes = 192 bits of entropy. Operators with stricter
+    requirements can pass ``--length`` (in url-safe bytes).
+    """
+    import json as _json
+    import os as _os
+    import secrets as _secrets
+
+    length = max(16, int(args.length))
+    grace_seconds = int(args.grace_seconds)
+    new_token = _secrets.token_urlsafe(length)
+
+    current_multi = _os.environ.get("MIND_MEM_TOKENS", "").strip()
+    current_single = _os.environ.get("MIND_MEM_TOKEN", "").strip()
+
+    existing: list[str] = []
+    if current_multi:
+        existing = [t.strip() for t in current_multi.split(",") if t.strip()]
+    elif current_single:
+        existing = [current_single]
+
+    # Rotation set: new token canonical FIRST (clients minted after
+    # rotation use it; the old set stays valid through grace).
+    rotated_set = [new_token, *[t for t in existing if t != new_token]]
+    final_set = [new_token]
+
+    report = {
+        "new_token": new_token,
+        "active_tokens_after_rotate": rotated_set,
+        "active_tokens_after_grace": final_set,
+        "grace_seconds": grace_seconds,
+        "shell": f"export MIND_MEM_TOKENS={','.join(rotated_set)}",
+        "shell_final": f"export MIND_MEM_TOKENS={','.join(final_set)}",
+        "instructions": (
+            "1. Run the 'shell' export now to authorise the new token "
+            "while old tokens stay valid through the grace window.  "
+            "2. Distribute the new_token to clients.  "
+            "3. After grace_seconds, run 'shell_final' to drop the old "
+            "tokens.  The HTTP transport reads MIND_MEM_TOKENS at each "
+            "request so no restart is required."
+        ),
+    }
+    print(_json.dumps(report, indent=2))
+    return 0
+
+
 def _cmd_verify_model(args: argparse.Namespace) -> int:
     from mind_mem.model_signing import ED25519_PUBLIC_KEY_BYTES, verify_model
 
@@ -1872,6 +1943,16 @@ def build_parser() -> argparse.ArgumentParser:
     p_recall.add_argument("query")
     p_recall.add_argument("--limit", type=int, default=10)
     p_recall.add_argument("--active-only", action="store_true")
+    p_recall.add_argument(
+        "--since",
+        default=None,
+        help="ISO-8601 lower bound on block Date (inclusive). E.g. --since 2026-01-01.",
+    )
+    p_recall.add_argument(
+        "--until",
+        default=None,
+        help="ISO-8601 upper bound on block Date (inclusive). E.g. --until 2026-12-31.",
+    )
     p_recall.set_defaults(func=_cmd_recall)
 
     # context
@@ -2034,6 +2115,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Add v2-schema columns (intent_type, stage_counts) to the SQLite retrieval_log.",
     )
     p_doctor.set_defaults(func=_cmd_doctor)
+
+    # token namespace — rotation primitive (roadmap v4.0.x federation hardening)
+    p_token = sub.add_parser(
+        "token",
+        help="Federation/HTTP transport token management (rotation primitive).",
+    )
+    tsub = p_token.add_subparsers(dest="token_cmd", required=True)
+    t_rotate = tsub.add_parser(
+        "rotate",
+        help="Mint a new token and emit the rotation hint (N-of-K active tokens with grace window; no server restart required).",
+    )
+    t_rotate.add_argument(
+        "--length",
+        type=int,
+        default=24,
+        help="Token entropy in url-safe bytes (default 24 = 192 bits).",
+    )
+    t_rotate.add_argument(
+        "--grace-seconds",
+        type=int,
+        default=86_400,
+        help="Grace window during which old tokens remain valid (default 24 h).",
+    )
+    t_rotate.set_defaults(func=_cmd_token_rotate)
 
     # vault namespace
     p_vault = sub.add_parser("vault", help="Vault sync subcommands.")

--- a/src/mind_mem/pipeline_hash.py
+++ b/src/mind_mem/pipeline_hash.py
@@ -61,6 +61,7 @@ _PACKAGE_ROOT = os.path.dirname(os.path.abspath(__file__))
 _BACKEND_SOURCE_FILES: dict[str, str] = {
     "ollama": os.path.join(_PACKAGE_ROOT, "llm_extractor.py"),
     "openai-compatible": os.path.join(_PACKAGE_ROOT, "llm_extractor.py"),
+    "mindllm": os.path.join(_PACKAGE_ROOT, "llm_extractor.py"),
     "llama-cpp": os.path.join(_PACKAGE_ROOT, "llm_extractor.py"),
     "transformers": os.path.join(_PACKAGE_ROOT, "llm_extractor.py"),
     # Default / unknown backends fall through to a stub hash so an unknown

--- a/tests/test_decrypt_file_audit_trail.py
+++ b/tests/test_decrypt_file_audit_trail.py
@@ -1,0 +1,135 @@
+"""Regression test for the `decrypt_file` forensic audit trail
+(N-08, roadmap v4.0.15).
+
+Every successful ``decrypt_file`` invocation appends a JSON line to
+``memory/decrypted_files.jsonl`` carrying timestamp + path + actor +
+mode. The trail is append-only; pair with the T-007 operator runbook
+at ``docs/append-only-audit-logs.md`` for the OS-level
+append-only attribute (``chattr +a`` / ``chflags uappnd``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def encrypted_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Build a workspace + encrypt a real file so decrypt_file has work."""
+    ws = tmp_path / "ws"
+    (ws / "memory").mkdir(parents=True)
+    (ws / "decisions").mkdir()
+    monkeypatch.setenv("MIND_MEM_ENCRYPTION_PASSPHRASE", "test-passphrase")
+    monkeypatch.setenv("MIND_MEM_WORKSPACE", str(ws))
+    monkeypatch.setenv("MIND_MEM_VAULT_ALLOWLIST", str(ws))
+    # decrypt_file is admin-scope; we need MIND_MEM_SCOPE=admin to bypass
+    # the ACL gate in tests.
+    monkeypatch.setenv("MIND_MEM_SCOPE", "admin")
+
+    # Write + encrypt a real file via the EncryptionManager.
+    target = ws / "decisions" / "secret.md"
+    target.write_text("highly confidential statement")
+    from mind_mem.encryption import EncryptionManager
+
+    EncryptionManager(str(ws), "test-passphrase").encrypt_file(str(target))
+    return ws, target
+
+
+def test_decrypt_file_appends_jsonl_record(
+    encrypted_workspace: tuple[Path, Path],
+) -> None:
+    """A successful decrypt_file call must append one line to
+    memory/decrypted_files.jsonl carrying ts + path + actor + mode."""
+    from mind_mem.mcp.tools.encryption import decrypt_file
+
+    ws, target = encrypted_workspace
+    log = ws / "memory" / "decrypted_files.jsonl"
+    assert not log.exists()  # not created until first decrypt
+
+    out = decrypt_file(str(target))
+    parsed = json.loads(out)
+    assert "plaintext_b64" in parsed, f"decrypt failed: {parsed!r}"
+
+    assert log.exists(), "decrypted_files.jsonl not created"
+    lines = log.read_text().strip().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+
+    # Required fields per the doc.
+    assert "ts" in record
+    assert record["ts"].endswith("Z")  # ISO-8601 UTC marker
+    assert record["path"] == str(target)
+    assert "actor" in record
+    assert record["mode"] == "read"
+
+
+def test_decrypt_file_appends_one_record_per_call(
+    encrypted_workspace: tuple[Path, Path],
+) -> None:
+    """Each call appends a fresh line — never rewrites or truncates."""
+    from mind_mem.mcp.tools.encryption import decrypt_file
+
+    ws, target = encrypted_workspace
+    log = ws / "memory" / "decrypted_files.jsonl"
+
+    for _ in range(3):
+        decrypt_file(str(target))
+
+    lines = log.read_text().strip().splitlines()
+    assert len(lines) == 3
+    # All three must parse and carry distinct timestamps (or at least
+    # be valid JSON — timestamps may collide at second granularity in
+    # a tight loop).
+    for line in lines:
+        rec = json.loads(line)
+        assert rec["path"] == str(target)
+        assert rec["mode"] == "read"
+
+
+def test_decrypt_file_failure_does_not_append(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When decrypt_file fails (bad path / missing passphrase), the
+    audit trail must NOT carry a line — only successful decrypts are
+    forensically interesting (a failure is observable in the error log)."""
+    ws = tmp_path / "ws"
+    (ws / "memory").mkdir(parents=True)
+    monkeypatch.setenv("MIND_MEM_ENCRYPTION_PASSPHRASE", "test-passphrase")
+    monkeypatch.setenv("MIND_MEM_WORKSPACE", str(ws))
+    monkeypatch.setenv("MIND_MEM_VAULT_ALLOWLIST", str(ws))
+    monkeypatch.setenv("MIND_MEM_SCOPE", "admin")
+
+    from mind_mem.mcp.tools.encryption import decrypt_file
+
+    # Path doesn't exist → decrypt failure.
+    out = decrypt_file(str(ws / "decisions" / "missing.md"))
+    parsed = json.loads(out)
+    assert "error" in parsed
+
+    log = ws / "memory" / "decrypted_files.jsonl"
+    # No successful decrypt happened → the audit file should not exist
+    # (or exist empty).
+    assert not log.exists() or log.read_text().strip() == ""
+
+
+def test_decrypt_file_audit_actor_defaults_to_anonymous(
+    encrypted_workspace: tuple[Path, Path],
+) -> None:
+    """In the absence of an explicit agent-id ContextVar, the audit
+    record carries 'anonymous' as the actor (best-effort attribution
+    — the ContextVar is populated by the REST + MCP layer; bare
+    function calls fall through to 'anonymous'). When the layer that
+    populates it is added (deferred audit attribution item), this
+    test gains a 'with actor=…' counterpart."""
+    from mind_mem.mcp.tools.encryption import decrypt_file
+
+    ws, target = encrypted_workspace
+    decrypt_file(str(target))
+
+    log = ws / "memory" / "decrypted_files.jsonl"
+    record = json.loads(log.read_text().strip().splitlines()[0])
+    assert record["actor"] == "anonymous"

--- a/tests/test_mindllm_backend.py
+++ b/tests/test_mindllm_backend.py
@@ -1,0 +1,117 @@
+"""Regression tests for the MindLLM backend (roadmap v4.0.15).
+
+MindLLM is STARGA's pure-MIND deterministic-inference HTTP server
+exposing OpenAI-compatible endpoints (``/v1/chat/completions``,
+``/v1/completions``, ``/v1/models``, ``/health``) plus a first-party
+RFN classifier endpoint. Bit-identical output across runs; per-token
+cryptographic evidence chain.
+
+mind-mem treats MindLLM as just another OpenAI-compatible backend at
+the wire level — the value-add is the deterministic + evidence-chain
+guarantees, not a new protocol. This test surface just confirms the
+``mindllm`` backend type is recognised, routes to MindLLM's default
+URL (port 8080), and round-trips through the existing OpenAI-compatible
+query path.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from mind_mem import llm_extractor
+
+# ---------------------------------------------------------------------------
+# Default URL + env-var override
+# ---------------------------------------------------------------------------
+
+
+def test_mindllm_default_url() -> None:
+    """When MIND_MEM_MINDLLM_URL is unset, default to localhost:8080/v1."""
+    os.environ.pop("MIND_MEM_MINDLLM_URL", None)
+    assert llm_extractor._mindllm_url() == "http://localhost:8080/v1"
+
+
+def test_mindllm_url_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MIND_MEM_MINDLLM_URL overrides the default; trailing slash stripped."""
+    monkeypatch.setenv("MIND_MEM_MINDLLM_URL", "http://prod-mindllm.local:8443/v1/")
+    assert llm_extractor._mindllm_url() == "http://prod-mindllm.local:8443/v1"
+
+
+# ---------------------------------------------------------------------------
+# Backend type recognition
+# ---------------------------------------------------------------------------
+
+
+def test_mindllm_backend_recognised(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``backend="mindllm"`` routes through is_available; aliases accepted."""
+    # No MindLLM server running in CI — is_available returns False but
+    # MUST NOT raise / return None on the recognised backend name.
+    monkeypatch.setenv("MIND_MEM_MINDLLM_URL", "http://127.0.0.1:9 /v1")  # unreachable
+    # Replace probe with a known-false to avoid network flake.
+    monkeypatch.setattr(llm_extractor, "_openai_compatible_available", lambda url: False)
+    assert llm_extractor.is_available("mindllm") is False
+    assert llm_extractor.is_available("mind-llm") is False  # alias
+    assert llm_extractor.is_available("mind_llm") is False  # alias
+
+
+def test_mindllm_backend_reports_available_when_probe_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``_openai_compatible_available`` returns True for MindLLM URL,
+    ``is_available("mindllm")`` must be True."""
+    monkeypatch.setattr(
+        llm_extractor,
+        "_openai_compatible_available",
+        lambda url: url.startswith("http://localhost:8080"),
+    )
+    assert llm_extractor.is_available("mindllm") is True
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery order includes MindLLM
+# ---------------------------------------------------------------------------
+
+
+def test_auto_discovery_includes_mindllm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``backend="auto"`` must try MindLLM before vLLM / openai-compatible
+    so deployments running MindLLM are picked up without explicit config."""
+    visited: list[str] = []
+
+    def fake_oai(url: str) -> bool:
+        visited.append(url)
+        return False
+
+    monkeypatch.setattr(llm_extractor, "_ollama_available", lambda: False)
+    monkeypatch.setattr(llm_extractor, "_llama_cpp_available", lambda: False)
+    monkeypatch.setattr(llm_extractor, "_transformers_available", lambda: False)
+    monkeypatch.setattr(llm_extractor, "_openai_compatible_available", fake_oai)
+
+    # Trigger auto path; result False because everything we patched returns False.
+    llm_extractor.is_available("auto")
+
+    # MindLLM must have been probed and BEFORE vLLM (so MindLLM users
+    # don't have to set explicit config when both are running).
+    assert any("8080" in u for u in visited), f"MindLLM port 8080 not probed: {visited}"
+    mindllm_idx = next(i for i, u in enumerate(visited) if "8080" in u)
+    vllm_idx_candidates = [i for i, u in enumerate(visited) if "8000" in u]
+    if vllm_idx_candidates:
+        assert mindllm_idx < vllm_idx_candidates[0], f"MindLLM should be probed before vLLM in auto-discovery; got order {visited}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-hash treats MindLLM as a known backend (not the unknown stub)
+# ---------------------------------------------------------------------------
+
+
+def test_mindllm_backend_in_pipeline_hash_known_backends() -> None:
+    """``pipeline_hash._BACKEND_SOURCE_FILES`` must include ``mindllm`` so
+    the pipeline-hash for a MindLLM-configured workspace doesn't fall
+    through to the unknown-backend stub hash."""
+    from mind_mem import pipeline_hash
+
+    assert "mindllm" in pipeline_hash._BACKEND_SOURCE_FILES
+    # And it points at the same llm_extractor.py source as ollama (same
+    # extraction logic; just a different HTTP endpoint).
+    assert pipeline_hash._BACKEND_SOURCE_FILES["mindllm"] == pipeline_hash._BACKEND_SOURCE_FILES["ollama"]

--- a/tests/test_recall_time_bounded.py
+++ b/tests/test_recall_time_bounded.py
@@ -1,0 +1,222 @@
+"""Regression tests for time-bounded recall (roadmap v4.0.0 Group E).
+
+``recall(workspace, query, *, since=ISO, until=ISO)`` post-filters hits
+by block ``Date`` field. Comparison is string-based on ISO-8601 so
+``YYYY-MM-DD`` and full timestamps both work. Filtering applies AFTER
+ranking + reranking — date is a post-filter, not a retrieval-time
+prefilter, so ranking quality is preserved.
+
+Also covers ``mm recall --since/--until`` CLI flags.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from mind_mem import mm_cli
+from mind_mem._recall_core import (
+    _apply_date_filter,
+    _block_date,
+    _in_date_range,
+    recall,
+)
+from mind_mem.sqlite_index import build_index
+
+# ---------------------------------------------------------------------------
+# Helper invariants
+# ---------------------------------------------------------------------------
+
+
+def test_block_date_reads_uppercase_key() -> None:
+    assert _block_date({"Date": "2026-01-15"}) == "2026-01-15"
+
+
+def test_block_date_falls_back_to_lowercase_key() -> None:
+    assert _block_date({"date": "2026-01-15"}) == "2026-01-15"
+
+
+def test_block_date_strips_whitespace() -> None:
+    assert _block_date({"Date": "  2026-01-15  "}) == "2026-01-15"
+
+
+def test_block_date_returns_none_for_missing() -> None:
+    assert _block_date({"id": "BLOCK-1"}) is None
+
+
+def test_in_date_range_open_both_sides() -> None:
+    """Both bounds None = unconstrained = accept everything (incl. None date)."""
+    assert _in_date_range(None, None, None) is True
+    assert _in_date_range("2026-06-01", None, None) is True
+
+
+def test_in_date_range_rejects_none_when_bound_set() -> None:
+    """When a bound is set, a block without a date can't satisfy it."""
+    assert _in_date_range(None, "2026-01-01", None) is False
+    assert _in_date_range(None, None, "2026-12-31") is False
+
+
+def test_in_date_range_inclusive_bounds() -> None:
+    """Bounds are inclusive."""
+    assert _in_date_range("2026-01-01", "2026-01-01", "2026-12-31") is True
+    assert _in_date_range("2026-12-31", "2026-01-01", "2026-12-31") is True
+
+
+def test_in_date_range_excludes_outside() -> None:
+    assert _in_date_range("2025-12-31", "2026-01-01", None) is False
+    assert _in_date_range("2027-01-01", None, "2026-12-31") is False
+
+
+def test_apply_date_filter_keeps_in_range() -> None:
+    hits = [
+        {"_id": "A", "Date": "2026-03-01"},
+        {"_id": "B", "Date": "2026-06-15"},
+        {"_id": "C", "Date": "2026-12-31"},
+        {"_id": "D", "Date": "2027-01-01"},
+        {"_id": "E"},  # no date
+    ]
+    filtered = _apply_date_filter(hits, since="2026-06-01", until="2026-12-31")
+    ids = [h["_id"] for h in filtered]
+    assert ids == ["B", "C"]  # in-range only; no-date dropped
+
+
+def test_apply_date_filter_no_bounds_is_passthrough() -> None:
+    hits = [{"_id": "A", "Date": "2026-01-01"}, {"_id": "B"}]
+    assert _apply_date_filter(hits, None, None) == hits
+
+
+# ---------------------------------------------------------------------------
+# recall() honours since/until end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def time_bounded_workspace(tmp_path) -> str:
+    """Workspace with 5 blocks spanning Jan-Dec 2026, all matching a query."""
+    ws = tmp_path / "tb"
+    (ws / "decisions").mkdir(parents=True)
+    blocks = [
+        ("FACT-Q1", "2026-02-15", "I love quarterly planning meetings"),
+        ("FACT-Q2", "2026-05-15", "I love quarterly planning meetings"),
+        ("FACT-Q3", "2026-08-15", "I love quarterly planning meetings"),
+        ("FACT-Q4", "2026-11-15", "I love quarterly planning meetings"),
+        ("FACT-OLD", "2025-12-20", "I love quarterly planning meetings"),
+    ]
+    body = ""
+    for bid, date, statement in blocks:
+        body += f"[{bid}]\nStatement: {statement}\nDate: {date}\nStatus: active\nTags: FACT\nSources: TEST\n\n---\n\n"
+    (ws / "decisions" / "DECISIONS.md").write_text(body)
+    # Configure SQLite backend with no LLM/CE — pure BM25 path.
+    (ws / "mind-mem.json").write_text(
+        json.dumps(
+            {
+                "recall": {
+                    "backend": "sqlite",
+                    "knee_cutoff": False,
+                    "cross_encoder": {"enabled": False, "auto_enable": False},
+                    "dedup": {"enabled": False, "type_cap_enabled": False, "source_cap_enabled": False},
+                }
+            }
+        )
+    )
+    os.environ.setdefault("MIND_MEM_DISABLE_TELEMETRY", "1")
+    build_index(str(ws), incremental=False)
+    return str(ws)
+
+
+def test_recall_no_filter_returns_all_matching(time_bounded_workspace: str) -> None:
+    """Sanity: without since/until, all 5 quarterly blocks come back."""
+    hits = recall(time_bounded_workspace, "love", limit=20, active_only=False)
+    ids = {h["_id"] for h in hits if h.get("_id", "").startswith("FACT-")}
+    assert ids == {"FACT-Q1", "FACT-Q2", "FACT-Q3", "FACT-Q4", "FACT-OLD"}
+
+
+def test_recall_with_since_filters_lower_bound(time_bounded_workspace: str) -> None:
+    """since=2026-06-01 keeps only Q3 + Q4."""
+    hits = recall(
+        time_bounded_workspace,
+        "love",
+        limit=20,
+        active_only=False,
+        since="2026-06-01",
+    )
+    ids = {h["_id"] for h in hits if h.get("_id", "").startswith("FACT-")}
+    assert ids == {"FACT-Q3", "FACT-Q4"}
+
+
+def test_recall_with_until_filters_upper_bound(time_bounded_workspace: str) -> None:
+    """until=2026-06-30 keeps Q1, Q2, and the OLD 2025 block."""
+    hits = recall(
+        time_bounded_workspace,
+        "love",
+        limit=20,
+        active_only=False,
+        until="2026-06-30",
+    )
+    ids = {h["_id"] for h in hits if h.get("_id", "").startswith("FACT-")}
+    assert ids == {"FACT-Q1", "FACT-Q2", "FACT-OLD"}
+
+
+def test_recall_with_both_bounds(time_bounded_workspace: str) -> None:
+    """Bounded both sides → middle two quarters only."""
+    hits = recall(
+        time_bounded_workspace,
+        "love",
+        limit=20,
+        active_only=False,
+        since="2026-03-01",
+        until="2026-09-30",
+    )
+    ids = {h["_id"] for h in hits if h.get("_id", "").startswith("FACT-")}
+    assert ids == {"FACT-Q2", "FACT-Q3"}
+
+
+def test_recall_with_impossible_range_returns_empty(time_bounded_workspace: str) -> None:
+    """No date in the workspace falls in 2030 → empty result."""
+    hits = recall(
+        time_bounded_workspace,
+        "love",
+        limit=20,
+        active_only=False,
+        since="2030-01-01",
+        until="2030-12-31",
+    )
+    # Some non-FACT blocks may still surface from the index — only assert
+    # that none of our FACT-* dated blocks survived.
+    fact_ids = [h["_id"] for h in hits if h.get("_id", "").startswith("FACT-")]
+    assert fact_ids == []
+
+
+def test_recall_filter_respects_limit(time_bounded_workspace: str) -> None:
+    """When filtering shrinks the set below `limit`, return shorter list."""
+    hits = recall(
+        time_bounded_workspace,
+        "love",
+        limit=20,
+        active_only=False,
+        since="2026-09-01",
+    )
+    fact = [h for h in hits if h.get("_id", "").startswith("FACT-")]
+    assert len(fact) == 1  # only Q4
+    assert fact[0]["_id"] == "FACT-Q4"
+
+
+# ---------------------------------------------------------------------------
+# CLI flag wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cli_recognises_since_until() -> None:
+    parser = mm_cli.build_parser()
+    args = parser.parse_args(["recall", "test query", "--since", "2026-01-01", "--until", "2026-06-30"])
+    assert args.since == "2026-01-01"
+    assert args.until == "2026-06-30"
+
+
+def test_cli_since_until_default_to_none() -> None:
+    parser = mm_cli.build_parser()
+    args = parser.parse_args(["recall", "test query"])
+    assert args.since is None
+    assert args.until is None

--- a/tests/test_token_rotation.py
+++ b/tests/test_token_rotation.py
@@ -1,0 +1,183 @@
+"""Regression tests for the token rotation primitive (roadmap v4.0.x).
+
+``mm token rotate`` mints a new url-safe token (192-bit by default)
+and emits the shell export to use it. The HTTP transport reads
+``MIND_MEM_TOKENS`` (comma-separated) on every request so no restart
+is needed. During the grace window both old and new tokens
+authenticate; after the grace window the operator drops the old
+entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from mind_mem import http_transport, mm_cli
+
+# ---------------------------------------------------------------------------
+# _active_tokens helper — fallback ladder
+# ---------------------------------------------------------------------------
+
+
+def test_active_tokens_reads_multi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MIND_MEM_TOKENS takes precedence over MIND_MEM_TOKEN + fallback."""
+    monkeypatch.setenv("MIND_MEM_TOKENS", "tok-a,tok-b , tok-c")
+    monkeypatch.setenv("MIND_MEM_TOKEN", "stale-single")
+    assert http_transport._active_tokens(fallback="ignored") == [
+        "tok-a",
+        "tok-b",
+        "tok-c",
+    ]
+
+
+def test_active_tokens_falls_back_to_single(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When MIND_MEM_TOKENS unset, fall back to MIND_MEM_TOKEN."""
+    monkeypatch.delenv("MIND_MEM_TOKENS", raising=False)
+    monkeypatch.setenv("MIND_MEM_TOKEN", "only-token")
+    assert http_transport._active_tokens(fallback=None) == ["only-token"]
+
+
+def test_active_tokens_falls_back_to_handler_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When neither env var is set, fall back to the handler-bound token."""
+    monkeypatch.delenv("MIND_MEM_TOKENS", raising=False)
+    monkeypatch.delenv("MIND_MEM_TOKEN", raising=False)
+    assert http_transport._active_tokens(fallback="startup-token") == ["startup-token"]
+
+
+def test_active_tokens_empty_when_nothing_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No env, no fallback → empty list (authentication fails closed)."""
+    monkeypatch.delenv("MIND_MEM_TOKENS", raising=False)
+    monkeypatch.delenv("MIND_MEM_TOKEN", raising=False)
+    assert http_transport._active_tokens(fallback=None) == []
+
+
+def test_active_tokens_strips_empty_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty entries (',,,', trailing comma) are stripped, not counted."""
+    monkeypatch.setenv("MIND_MEM_TOKENS", ",,real-token,,")
+    assert http_transport._active_tokens(fallback=None) == ["real-token"]
+
+
+# ---------------------------------------------------------------------------
+# `mm token rotate` CLI — output schema + entropy
+# ---------------------------------------------------------------------------
+
+
+def test_token_rotate_emits_required_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`mm token rotate` prints a JSON report with the documented fields."""
+    monkeypatch.delenv("MIND_MEM_TOKENS", raising=False)
+    monkeypatch.delenv("MIND_MEM_TOKEN", raising=False)
+    ns = argparse.Namespace(length=24, grace_seconds=3600)
+    rc = mm_cli._cmd_token_rotate(ns)
+    assert rc == 0
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    for key in (
+        "new_token",
+        "active_tokens_after_rotate",
+        "active_tokens_after_grace",
+        "grace_seconds",
+        "shell",
+        "shell_final",
+        "instructions",
+    ):
+        assert key in report, f"missing field {key!r}"
+    # New token must be url-safe (no padding, no slashes) and length ≥ 24.
+    assert len(report["new_token"]) >= 24
+    assert "/" not in report["new_token"]
+    assert "+" not in report["new_token"]
+    # The shell export must add the new token to MIND_MEM_TOKENS.
+    assert "MIND_MEM_TOKENS=" in report["shell"]
+    assert report["new_token"] in report["shell"]
+
+
+def test_token_rotate_grace_window_preserves_existing_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When MIND_MEM_TOKENS already has tokens, rotation appends — the
+    new set MUST include both the new token AND every previous token
+    so in-flight clients stay authenticated through the grace window."""
+    monkeypatch.setenv("MIND_MEM_TOKENS", "old-token-1,old-token-2")
+    monkeypatch.delenv("MIND_MEM_TOKEN", raising=False)
+    ns = argparse.Namespace(length=24, grace_seconds=86400)
+    mm_cli._cmd_token_rotate(ns)
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    rotated = report["active_tokens_after_rotate"]
+    assert "old-token-1" in rotated
+    assert "old-token-2" in rotated
+    assert report["new_token"] in rotated
+    # New token is first (canonical write token going forward).
+    assert rotated[0] == report["new_token"]
+    # After grace: only the new token remains.
+    assert report["active_tokens_after_grace"] == [report["new_token"]]
+
+
+def test_token_rotate_falls_back_to_single_token(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Single-token deployment (MIND_MEM_TOKEN only) rotates into the
+    multi-token set so the operator can upgrade rotation discipline
+    without a re-bootstrap."""
+    monkeypatch.delenv("MIND_MEM_TOKENS", raising=False)
+    monkeypatch.setenv("MIND_MEM_TOKEN", "legacy-single")
+    ns = argparse.Namespace(length=24, grace_seconds=3600)
+    mm_cli._cmd_token_rotate(ns)
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    assert "legacy-single" in report["active_tokens_after_rotate"]
+
+
+# ---------------------------------------------------------------------------
+# Token entropy floor
+# ---------------------------------------------------------------------------
+
+
+def test_token_rotate_enforces_min_length(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--length`` below 16 is silently floored to 16 (minimum entropy)."""
+    ns = argparse.Namespace(length=4, grace_seconds=60)  # request too small
+    mm_cli._cmd_token_rotate(ns)
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    # 16 url-safe bytes ≈ 22 chars after base64-url encoding.
+    assert len(report["new_token"]) >= 22
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: parser recognises `mm token rotate`
+# ---------------------------------------------------------------------------
+
+
+def test_cli_parser_recognises_token_rotate() -> None:
+    """``mm token rotate`` must be a registered subcommand."""
+    parser = mm_cli.build_parser()
+    args = parser.parse_args(["token", "rotate"])
+    assert args.func is mm_cli._cmd_token_rotate
+    assert args.length == 24
+    assert args.grace_seconds == 86_400
+
+
+def test_cli_parser_accepts_token_rotate_flags() -> None:
+    """``--length`` and ``--grace-seconds`` are wired."""
+    parser = mm_cli.build_parser()
+    args = parser.parse_args(["token", "rotate", "--length", "32", "--grace-seconds", "300"])
+    assert args.length == 32
+    assert args.grace_seconds == 300


### PR DESCRIPTION
Five-item roadmap-cluster release closing genuine-open items across federation hardening, Group E (compliance), Group G (ecosystem), and the 2026-04-28 security audit remainders.

## What ships

1. **MindLLM backend** (`mindllm`) — first-class OpenAI-compatible LLM backend for STARGA's pure-MIND deterministic-inference server. Default `http://localhost:8080/v1`; `auto`-discovery probes MindLLM before vLLM. 6 new tests.
2. **Token rotation primitive** — `MIND_MEM_TOKENS` N-of-K active tokens + `mm token rotate` CLI. Read on every request, no restart. 11 new tests. Closes 3rd of 4 federation hardening gaps.
3. **Time-bounded recall** — `recall(..., since=, until=)` ISO-8601 post-rank filter. `mm recall --since/--until` CLI flags. 18 new tests.
4. **Companion-tools docs** — `docs/companion-tools.md` for MindLLM (backend) + GitNexus (sibling MCP).
5. **N-08 + T-007 closeouts** — `decrypt_file` appends to `memory/decrypted_files.jsonl`; `docs/append-only-audit-logs.md` operator runbook for `chattr +a` / `chflags uappnd` / `icacls`. 4 new tests.

## Green-gate
- **5153 passed, 27 skipped, 0 failed** non-stress (+39 vs v4.0.14)
- ruff check + ruff format clean
- mypy clean on changed surfaces
- 0 open code-scanning alerts (carried from v4.0.14)

## Deferred (tracked in ROADMAP)
- `event_id` filter on `recall` (needs event-store hook design)
- Block versioning + time-travel (`as_of=`, `block_history`)
- OpenAPI / AsyncAPI specs export
- Per-peer identity binding (federation token → agent_id table)

STARGA-authored. No co-authors. No AI attribution.